### PR TITLE
Fix/actions issue solution

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,3 +8,5 @@
 # Important notes
 
 The GITHUB_TOKEN used by the GitHub Copilot Cloud Agent should never be used to retrieve data for items in the ./data folder.
+
+When adding a new fetch workflow, ensure it includes both a "Commit new files" step (runs only on `main`, i.e. `if: github.ref == 'refs/heads/main'`) and a "Simulate commit (non-default branch)" step (runs on all other branches, logs what would have been committed without pushing).

--- a/.github/workflows/fetch-eclipse.yml
+++ b/.github/workflows/fetch-eclipse.yml
@@ -31,6 +31,7 @@ jobs:
         run: python -m scripts.run --ide eclipse
 
       - name: Commit new files
+        if: github.ref == 'refs/heads/main'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -40,4 +41,16 @@ jobs:
           else
             git commit -m "chore(eclipse): add new release notes [skip ci]"
             git push
+          fi
+
+      - name: Simulate commit (non-default branch)
+        if: github.ref != 'refs/heads/main'
+        run: |
+          git add data/eclipse/
+          if git diff --staged --quiet; then
+            echo "No new releases — nothing to commit."
+          else
+            echo "Running on non-default branch (${{ github.ref_name }}) — skipping commit."
+            echo "Files that would have been committed:"
+            git diff --staged --name-only
           fi

--- a/.github/workflows/fetch-jetbrains.yml
+++ b/.github/workflows/fetch-jetbrains.yml
@@ -29,6 +29,7 @@ jobs:
         run: python -m scripts.run --ide jetbrains
 
       - name: Commit new files
+        if: github.ref == 'refs/heads/main'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -38,4 +39,16 @@ jobs:
           else
             git commit -m "chore(jetbrains): add new release notes [skip ci]"
             git push
+          fi
+
+      - name: Simulate commit (non-default branch)
+        if: github.ref != 'refs/heads/main'
+        run: |
+          git add data/jetbrains/
+          if git diff --staged --quiet; then
+            echo "No new releases — nothing to commit."
+          else
+            echo "Running on non-default branch (${{ github.ref_name }}) — skipping commit."
+            echo "Files that would have been committed:"
+            git diff --staged --name-only
           fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,3 +44,7 @@ tests/                       – pytest test suite
 Each workflow runs on a daily cron and can also be triggered manually via `workflow_dispatch`.
 It commits any newly written files directly to `main`. If the fetcher produces no new files no
 commit is made (no empty commits).
+
+When a workflow is triggered on a non-default branch, the commit step is skipped. Instead, a
+"Simulate commit" step logs which files *would* have been committed, allowing safe testing of
+the fetch logic on feature branches without writing to the repository.

--- a/data/eclipse/0.17.0.json
+++ b/data/eclipse/0.17.0.json
@@ -1,0 +1,22 @@
+{
+  "ide": "eclipse",
+  "version": "0.17.0",
+  "release_date": "2026-05-08",
+  "title": "0.17.0 - 20260508",
+  "url": "https://github.com/microsoft/copilot-for-eclipse/releases/tag/0.17.0",
+  "source": "api",
+  "body_markdown": "### Added\n- Add context size donut and popup for visualizing token usage.\n- Add rate limit warning banner in chat view. [PR#17](https://github.com/microsoft/copilot-for-eclipse/pull/17)\n- Support delegating read directory to IDE. [PR#18](https://github.com/microsoft/copilot-for-eclipse/pull/18)\n- Support delegating file and text search to IDE. [PR#22](https://github.com/microsoft/copilot-for-eclipse/pull/22)\n- Support custom models (BYOK) for Copilot Business and Enterprise users. [PR#140](https://github.com/microsoft/copilot-for-eclipse/pull/140)\n### Changed\n- Update the combos rendering and add context button style in chat view.\n### Fixed\n- Fix ConcurrentModificationException in CompletionProvider listener iteration. [PR#13](https://github.com/microsoft/copilot-for-eclipse/pull/13)\n- Fix capitalization of \"GitHub\" in signin description. [PR#10](https://github.com/microsoft/copilot-for-eclipse/pull/10)\n- Fix NES annotation type mapping and foreign text marker registration. [#23](https://github.com/microsoft/copilot-for-eclipse/issues/23)",
+  "body_html": "### Added\r\n- Add context size donut and popup for visualizing token usage.\r\n- Add rate limit warning banner in chat view. [PR#17](https://github.com/microsoft/copilot-for-eclipse/pull/17)\r\n- Support delegating read directory to IDE. [PR#18](https://github.com/microsoft/copilot-for-eclipse/pull/18)\r\n- Support delegating file and text search to IDE. [PR#22](https://github.com/microsoft/copilot-for-eclipse/pull/22)\r\n- Support custom models (BYOK) for Copilot Business and Enterprise users. [PR#140](https://github.com/microsoft/copilot-for-eclipse/pull/140)\r\n\r\n### Changed\r\n- Update the combos rendering and add context button style in chat view.\r\n\r\n### Fixed\r\n- Fix ConcurrentModificationException in CompletionProvider listener iteration. [PR#13](https://github.com/microsoft/copilot-for-eclipse/pull/13)\r\n- Fix capitalization of \"GitHub\" in signin description. [PR#10](https://github.com/microsoft/copilot-for-eclipse/pull/10)\r\n- Fix NES annotation type mapping and foreign text marker registration. [#23](https://github.com/microsoft/copilot-for-eclipse/issues/23)",
+  "categories": [],
+  "copilot_mentions": [
+    "- Add rate limit warning banner in chat view. [PR#17](https://github.com/microsoft/copilot-for-eclipse/pull/17)",
+    "- Support delegating read directory to IDE. [PR#18](https://github.com/microsoft/copilot-for-eclipse/pull/18)",
+    "- Support delegating file and text search to IDE. [PR#22](https://github.com/microsoft/copilot-for-eclipse/pull/22)",
+    "- Support custom models (BYOK) for Copilot Business and Enterprise users. [PR#140](https://github.com/microsoft/copilot-for-eclipse/pull/140)",
+    "- Fix ConcurrentModificationException in CompletionProvider listener iteration. [PR#13](https://github.com/microsoft/copilot-for-eclipse/pull/13)",
+    "- Fix capitalization of \"GitHub\" in signin description. [PR#10](https://github.com/microsoft/copilot-for-eclipse/pull/10)",
+    "- Fix NES annotation type mapping and foreign text marker registration. [#23](https://github.com/microsoft/copilot-for-eclipse/issues/23)"
+  ],
+  "fetched_at": "2026-05-09T20:22:47Z",
+  "schema_version": 1
+}

--- a/scripts/common/http.py
+++ b/scripts/common/http.py
@@ -84,9 +84,13 @@ def get_json(
     return response.json()
 
 
-def get_text(url: str, *, params: dict | None = None) -> str:
-    """GET *url* and return the response body as text."""
-    session = get_session()
+def get_text(url: str, *, params: dict | None = None, use_auth: bool = True) -> str:
+    """GET *url* and return the response body as text.
+
+    Pass ``use_auth=False`` for third-party APIs that must not receive the
+    GitHub token in the Authorization header.
+    """
+    session = get_session() if use_auth else get_session_no_auth()
     response = session.get(url, params=params, timeout=_DEFAULT_TIMEOUT)
     response.raise_for_status()
     return response.text

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -6,7 +6,7 @@ import pytest
 import requests
 
 import scripts.common.http as http_module
-from scripts.common.http import get_session, _build_session
+from scripts.common.http import get_session, get_text, _build_session
 
 
 class TestBuildSession:
@@ -58,3 +58,54 @@ class TestGetSession:
         http_module._state["session"] = existing
         result = get_session()
         assert result is existing
+
+
+class TestGetText:
+    def setup_method(self):
+        http_module._state["session"] = None
+        http_module._state["session_no_auth"] = None
+
+    def teardown_method(self):
+        http_module._state["session"] = None
+        http_module._state["session_no_auth"] = None
+
+    def test_use_auth_true_uses_authenticated_session(self):
+        mock_response = MagicMock()
+        mock_response.text = "hello"
+        mock_session = MagicMock()
+        mock_session.get.return_value = mock_response
+
+        with patch.object(http_module, "get_session", return_value=mock_session) as mock_get_session, \
+             patch.object(http_module, "get_session_no_auth") as mock_no_auth:
+            result = get_text("https://api.github.com/something", use_auth=True)
+
+        mock_get_session.assert_called_once()
+        mock_no_auth.assert_not_called()
+        assert result == "hello"
+
+    def test_use_auth_false_uses_unauthenticated_session(self):
+        mock_response = MagicMock()
+        mock_response.text = "world"
+        mock_session = MagicMock()
+        mock_session.get.return_value = mock_response
+
+        with patch.object(http_module, "get_session_no_auth", return_value=mock_session) as mock_no_auth, \
+             patch.object(http_module, "get_session") as mock_get_session:
+            result = get_text("https://example.com/data", use_auth=False)
+
+        mock_no_auth.assert_called_once()
+        mock_get_session.assert_not_called()
+        assert result == "world"
+
+    def test_default_use_auth_is_true(self):
+        mock_response = MagicMock()
+        mock_response.text = "default"
+        mock_session = MagicMock()
+        mock_session.get.return_value = mock_response
+
+        with patch.object(http_module, "get_session", return_value=mock_session) as mock_get_session, \
+             patch.object(http_module, "get_session_no_auth") as mock_no_auth:
+            get_text("https://api.github.com/something")
+
+        mock_get_session.assert_called_once()
+        mock_no_auth.assert_not_called()


### PR DESCRIPTION
This pull request introduces improvements to the fetch workflows for Eclipse and JetBrains, enhances documentation for workflow behavior, and updates the HTTP utility and its tests to better handle authenticated and unauthenticated requests. Additionally, it adds a new Eclipse release note file.

**Workflow enhancements and documentation:**

* Both `fetch-eclipse.yml` and `fetch-jetbrains.yml` workflows now distinguish between running on the `main` branch and feature branches: commits of new files only occur on `main`, while on other branches, a "Simulate commit" step logs which files would have been committed, allowing safe testing without modifying the repository. [[1]](diffhunk://#diff-af9f894ba8451695750e7491ac9591ed16008d8ce0a04d5fd7a3152fc07620cbR34) [[2]](diffhunk://#diff-af9f894ba8451695750e7491ac9591ed16008d8ce0a04d5fd7a3152fc07620cbR45-R56) [[3]](diffhunk://#diff-e8659448bca134d35c94346a7f56257aa295daa3689f31040e1aea8e61ec27acR32) [[4]](diffhunk://#diff-e8659448bca134d35c94346a7f56257aa295daa3689f31040e1aea8e61ec27acR43-R54)
* Documentation in `.github/copilot-instructions.md` and `AGENTS.md` has been updated to clarify the new workflow behavior for fetch jobs, especially regarding commit and simulation steps on different branches. [[1]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R11-R12) [[2]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R47-R50)

**HTTP utility improvements:**

* The `get_text` function in `scripts/common/http.py` now accepts a `use_auth` parameter, allowing callers to explicitly choose whether to use an authenticated session (with the GitHub token) or an unauthenticated one, improving security for third-party API calls.
* Tests for `get_text` have been added to `tests/test_http.py` to verify correct session usage based on the `use_auth` parameter, ensuring robust behavior for both authenticated and unauthenticated requests. [[1]](diffhunk://#diff-c004679546311e65d99f8cf55b34e6eadd4e7f59061e36d7875fec4a3bc0bc15L9-R9) [[2]](diffhunk://#diff-c004679546311e65d99f8cf55b34e6eadd4e7f59061e36d7875fec4a3bc0bc15R61-R111)

**Data update:**

* Added new Eclipse release data file `data/eclipse/0.17.0.json`.