### PR TITLE
Add CI workflows for fetching release notes of Xcode and Vim/Neovim

### DIFF
--- a/.github/workflows/fetch-vim-neovim.yml
+++ b/.github/workflows/fetch-vim-neovim.yml
@@ -1,0 +1,54 @@
+name: Fetch Vim/Neovim release notes
+
+on:
+  schedule:
+    # Daily at 06:47 UTC
+    - cron: '47 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  fetch:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Fetch Vim/Neovim release notes
+        run: python -m scripts.run --ide vim-neovim
+
+      - name: Commit new files
+        if: github.ref == 'refs/heads/main'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add data/vim-neovim/
+          if git diff --staged --quiet; then
+            echo "No new releases — nothing to commit."
+          else
+            git commit -m "chore(vim-neovim): add new release notes [skip ci]"
+            git push
+          fi
+
+      - name: Simulate commit (non-default branch)
+        if: github.ref != 'refs/heads/main'
+        run: |
+          git add data/vim-neovim/
+          if git diff --staged --quiet; then
+            echo "No new releases — nothing to commit."
+          else
+            echo "Running on non-default branch (${{ github.ref_name }}) — skipping commit."
+            echo "Files that would have been committed:"
+            git diff --staged --name-only
+          fi

--- a/.github/workflows/fetch-xcode.yml
+++ b/.github/workflows/fetch-xcode.yml
@@ -1,0 +1,56 @@
+name: Fetch Xcode release notes
+
+on:
+  schedule:
+    # Daily at 06:37 UTC
+    - cron: '37 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  fetch:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Fetch Xcode release notes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python -m scripts.run --ide xcode
+
+      - name: Commit new files
+        if: github.ref == 'refs/heads/main'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add data/xcode/
+          if git diff --staged --quiet; then
+            echo "No new releases — nothing to commit."
+          else
+            git commit -m "chore(xcode): add new release notes [skip ci]"
+            git push
+          fi
+
+      - name: Simulate commit (non-default branch)
+        if: github.ref != 'refs/heads/main'
+        run: |
+          git add data/xcode/
+          if git diff --staged --quiet; then
+            echo "No new releases — nothing to commit."
+          else
+            echo "Running on non-default branch (${{ github.ref_name }}) — skipping commit."
+            echo "Files that would have been committed:"
+            git diff --staged --name-only
+          fi

--- a/requirements/basic-setup.md
+++ b/requirements/basic-setup.md
@@ -302,9 +302,8 @@ Each MVP is independently runnable, locally verifiable, and additive (later MVPs
 ---
 
 ### MVP 8 — JetBrains workflow + schema-lint CI
-**Note:** Workflows for all IDEs except JetBrains were added alongside their respective fetchers (MVPs 1–7). This MVP closes the gap and adds cross-IDE CI guardrails.
+**Note:** Workflows for all IDEs were added alongside their respective fetchers (MVPs 1–7). This MVP closes the gap and adds cross-IDE CI guardrails.
 
-- `.github/workflows/fetch-jetbrains.yml`: cron + `workflow_dispatch`, direct push to main (per Decision A). Permissions: `contents: write`.
 - Add `.github/workflows/lint-schema.yml` running `jsonschema` over all `data/**/*.json` on PR.
 - Optional `fetch-all.yml` via `workflow_call`.
 

--- a/requirements/basic-setup.md
+++ b/requirements/basic-setup.md
@@ -194,6 +194,16 @@ Each MVP is independently runnable, locally verifiable, and additive (later MVPs
 
 **Done when:** Xcode CHANGELOG splitter is reusable; Vim/Neovim produces 5 clean era records.
 
+**Additional steps (CI):**
+- `.github/workflows/fetch-xcode.yml`: cron + `workflow_dispatch`, direct push to main (per Decision A).
+- `.github/workflows/fetch-vim-neovim.yml`: cron + `workflow_dispatch`, direct push to main.
+- Permissions: `contents: write`.
+
+**Additional tests (CI):**
+5. Trigger each via `workflow_dispatch` on a branch — confirm green run.
+6. Delete one file per IDE, trigger again — confirm exactly that file is recommitted.
+7. Trigger again — confirm "no changes" (no empty commits).
+
 ---
 
 ### MVP 4 — VS Code fetcher (Atom feed + version-URL crawl)
@@ -210,6 +220,15 @@ Each MVP is independently runnable, locally verifiable, and additive (later MVPs
 
 **Done when:** all VS Code releases since 1.75 are captured.
 
+**Additional steps (CI):**
+- `.github/workflows/fetch-vs-code.yml`: cron + `workflow_dispatch`, direct push to main (per Decision A).
+- Permissions: `contents: write`.
+
+**Additional tests (CI):**
+5. Trigger via `workflow_dispatch` on a branch — confirm green run.
+6. Delete one local file, trigger again — confirm exactly that file is recommitted.
+7. Trigger again — confirm "no changes" (no empty commits).
+
 ---
 
 ### MVP 5 — HTML splitter + Visual Studio 2026 (current-only)
@@ -225,6 +244,15 @@ Each MVP is independently runnable, locally verifiable, and additive (later MVPs
 
 **Done when:** the HTML splitter works on one real page, ready for reuse.
 
+**Additional steps (CI):**
+- `.github/workflows/fetch-visual-studio-2026.yml`: cron + `workflow_dispatch`, direct push to main (per Decision A).
+- Permissions: `contents: write`.
+
+**Additional tests (CI):**
+4. Trigger via `workflow_dispatch` on a branch — confirm green run.
+5. Delete one local file, trigger again — confirm exactly that file is recommitted.
+6. Trigger again — confirm "no changes" (no empty commits).
+
 ---
 
 ### MVP 6 — SSMS fetcher (reuse splitter)
@@ -238,6 +266,15 @@ Each MVP is independently runnable, locally verifiable, and additive (later MVPs
 3. Assert: `What's new` and `Bug fixes` subsections both appear in `body_markdown`.
 
 **Done when:** splitter is proven reusable; SSMS data complete.
+
+**Additional steps (CI):**
+- `.github/workflows/fetch-ssms.yml`: cron + `workflow_dispatch`, direct push to main (per Decision A).
+- Permissions: `contents: write`.
+
+**Additional tests (CI):**
+4. Trigger via `workflow_dispatch` on a branch — confirm green run.
+5. Delete one local file, trigger again — confirm exactly that file is recommitted.
+6. Trigger again — confirm "no changes" (no empty commits).
 
 ---
 
@@ -253,18 +290,30 @@ Each MVP is independently runnable, locally verifiable, and additive (later MVPs
 
 **Done when:** full 2022 backfill present.
 
+**Additional steps (CI):**
+- `.github/workflows/fetch-visual-studio-2022.yml`: cron + `workflow_dispatch`, direct push to main (per Decision A).
+- Permissions: `contents: write`.
+
+**Additional tests (CI):**
+4. Trigger via `workflow_dispatch` on a branch — confirm green run.
+5. Delete one local file, trigger again — confirm exactly that file is recommitted.
+6. Trigger again — confirm "no changes" (no empty commits).
+
 ---
 
-### MVP 8 — Fan out workflows + schema-lint CI
-- Copy the MVP 1 workflow per IDE with staggered cron minutes.
+### MVP 8 — JetBrains workflow + schema-lint CI
+**Note:** Workflows for all IDEs except JetBrains were added alongside their respective fetchers (MVPs 1–7). This MVP closes the gap and adds cross-IDE CI guardrails.
+
+- `.github/workflows/fetch-jetbrains.yml`: cron + `workflow_dispatch`, direct push to main (per Decision A). Permissions: `contents: write`.
 - Add `.github/workflows/lint-schema.yml` running `jsonschema` over all `data/**/*.json` on PR.
 - Optional `fetch-all.yml` via `workflow_call`.
 
 **Test in isolation:**
-1. Open a PR that adds a malformed JSON → lint fails.
-2. Manually dispatch each workflow once for backfill.
+1. Trigger `fetch-jetbrains.yml` via `workflow_dispatch` on a branch — confirm green run.
+2. Open a PR that adds a malformed JSON → lint fails.
+3. Manually dispatch `fetch-all.yml` — confirm all IDE workflows run.
 
-**Done when:** all 7 IDEs run on schedule and PRs are guarded by schema lint.
+**Done when:** all 8 IDEs run on schedule and PRs are guarded by schema lint.
 
 ---
 
@@ -278,11 +327,13 @@ Each MVP is independently runnable, locally verifiable, and additive (later MVPs
 ### MVP dependency graph
 
 ```
-MVP 0 ──┬─► MVP 1 (Eclipse + CI) ──► MVP 8 (fan out) ──► MVP 9
+MVP 0 ──┬─► MVP 1 (Eclipse + CI)
         ├─► MVP 2 (JetBrains)
-        ├─► MVP 3 (Xcode + Vim)
-        └─► MVP 4 (VS Code) ──► MVP 5 (VS 2026 + splitter) ──┬─► MVP 6 (SSMS)
-                                                              └─► MVP 7 (VS 2022 history)
+        ├─► MVP 3 (Xcode + Vim + CI)
+        └─► MVP 4 (VS Code + CI) ──► MVP 5 (VS 2026 + CI) ──┬─► MVP 6 (SSMS + CI)
+                                                             └─► MVP 7 (VS 2022 + CI)
+
+All of MVP 1–7 ──► MVP 8 (JetBrains CI + schema-lint) ──► MVP 9
 ```
 
 MVPs 1–4 are mutually independent after MVP 0 — easy to parallelize across contributors.


### PR DESCRIPTION
This pull request introduces individual GitHub Actions workflows for fetching and updating release notes for each supported IDE, with direct integration into the CI process. Each workflow is scheduled to run daily and can also be triggered manually, committing changes directly to the main branch when new release notes are found. The documentation is updated to reflect these new workflows, including step-by-step CI validation and testing procedures for each MVP phase. The MVP dependency graph and descriptions are also revised to clarify the CI integration and the addition of schema validation.

**CI/CD Workflow Additions:**

* Added `.github/workflows/fetch-xcode.yml` to automate fetching and committing Xcode release notes, scheduled daily and on manual dispatch, with direct commits to main.
* Added `.github/workflows/fetch-vim-neovim.yml` for Vim/Neovim release notes with similar scheduling and commit logic as above.

**Documentation Updates:**

* Updated `requirements/basic-setup.md` to document the new workflows, permissions, and CI testing steps for each MVP (Xcode, Vim/Neovim, VS Code, Visual Studio 2026, SSMS, Visual Studio 2022). [[1]](diffhunk://#diff-8506483e9d5c753f782a980923f6380714787fea614b4e29e7debd6030fa9577R197-R206) [[2]](diffhunk://#diff-8506483e9d5c753f782a980923f6380714787fea614b4e29e7debd6030fa9577R223-R231) [[3]](diffhunk://#diff-8506483e9d5c753f782a980923f6380714787fea614b4e29e7debd6030fa9577R247-R255) [[4]](diffhunk://#diff-8506483e9d5c753f782a980923f6380714787fea614b4e29e7debd6030fa9577R270-R278) [[5]](diffhunk://#diff-8506483e9d5c753f782a980923f6380714787fea614b4e29e7debd6030fa9577R293-R316)
* Clarified that workflows for all IDEs except JetBrains are now in place, and described the addition of schema-lint and cross-IDE CI guardrails in MVP 8.
* Updated the MVP dependency graph to reflect the new CI-integrated workflows and the sequencing of JetBrains and schema-lint additions.