### PR TITLE
Added the MVP 4 implementation - VS Code

### DIFF
--- a/.github/workflows/fetch-vs-code.yml
+++ b/.github/workflows/fetch-vs-code.yml
@@ -1,0 +1,61 @@
+name: Fetch VS Code release notes
+
+on:
+  schedule:
+    # Daily at 06:29 UTC
+    - cron: '29 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  fetch:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Fetch VS Code release notes
+        run: python -m scripts.run --ide vs-code
+
+      - name: Commit new files
+        if: github.ref == 'refs/heads/main'
+        id: create-pr
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          add-paths: data/vs-code/
+          commit-message: "chore(vs-code): add new release notes"
+          branch: bot/fetch-vs-code
+          delete-branch: true
+          title: "chore(vs-code): add new release notes"
+          body: "Automated update: new release notes fetched by the daily workflow."
+
+      - name: Enable auto-merge
+        if: github.ref == 'refs/heads/main' && steps.create-pr.outputs.pull-request-number != ''
+        run: gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-number }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Simulate commit (non-default branch)
+        if: github.ref != 'refs/heads/main'
+        run: |
+          git add data/vs-code/
+          if git diff --staged --quiet; then
+            echo "No new releases — nothing to commit."
+          else
+            echo "Running on non-default branch (${{ github.ref_name }}) — skipping commit."
+            echo "Files that would have been committed:"
+            git diff --staged --name-only
+          fi

--- a/config/ides.yml
+++ b/config/ides.yml
@@ -32,8 +32,14 @@ ides:
     fetcher: copilot_vim
     source_url: https://docs.github.com/en/copilot/reference/copilot-feature-matrix?tool=vimneovim
 
+  - id: vs-code
+    name: GitHub Copilot for VS Code
+    data_dir: data/vs-code
+    fetcher: vs_code
+    start_version: "1.75.0"
+    source_url: https://code.visualstudio.com/feed.xml
+
   # Real IDE entries will be added in subsequent MVPs:
-  # - id: vs-code
   # - id: visual-studio-2022
   # - id: visual-studio-2026
   # - id: sql-server-management-studio

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,5 @@ requests>=2.32.0
 beautifulsoup4>=4.12.0
 lxml>=5.2.0
 markdownify>=0.13.0
+feedparser>=6.0.0
 pytest>=8.0.0

--- a/scripts/fetchers/vs_code.py
+++ b/scripts/fetchers/vs_code.py
@@ -1,0 +1,167 @@
+"""VS Code fetcher — release notes via Atom feed + per-version page scrape.
+
+Source:
+  Feed (latest ~30 entries): https://code.visualstudio.com/feed.xml
+  Per-version page          : https://code.visualstudio.com/updates/v1_<N>
+
+The feed is used only to discover the latest minor version N.  All versions
+from start_version up to (and including) the latest are then fetched by
+constructing the URL directly, so a full backfill is possible even when older
+entries have aged out of the feed.
+
+Version scheme: 1.<N>.0  (e.g. v1_75 → version "1.75.0")
+"""
+
+import json
+import re
+from datetime import datetime
+
+import feedparser
+from bs4 import BeautifulSoup
+
+from scripts.common.extract import extract_copilot_mentions, html_to_markdown
+from scripts.common.http import get_text
+
+_FEED_URL = "https://code.visualstudio.com/feed.xml"
+_RELEASE_URL_TEMPLATE = "https://code.visualstudio.com/updates/v1_{n}"
+# Matches the minor version in VS Code release-notes URLs (/updates/v1_75).
+_RELEASE_URL_RE = re.compile(r"/updates/v1_(\d+)")
+
+
+def _parse_minor_from_start_version(start_version: str) -> int:
+    """Return the minor part of a version string like '1.75.0' or '1.75'."""
+    parts = start_version.split(".")
+    if len(parts) < 2:
+        raise ValueError(f"Cannot extract minor version from start_version: {start_version!r}")
+    return int(parts[1])
+
+
+def _parse_feed(feed_xml: str) -> tuple[int, dict[int, str]]:
+    """Parse the Atom feed XML and return (latest_minor, {minor: date}).
+
+    Only entries whose tags include ``release`` and whose link matches the
+    ``/updates/v1_N`` pattern are considered.  Blog or other entries are
+    silently skipped.
+
+    Returns:
+        latest_minor: the highest minor N found in the feed.
+        feed_dates:   mapping of minor → ISO-8601 date string (YYYY-MM-DD).
+
+    Raises:
+        ValueError: when no release entries are found in the feed.
+    """
+    parsed = feedparser.parse(feed_xml)
+    feed_dates: dict[int, str] = {}
+
+    for entry in parsed.entries:
+        tags = [t.get("term", "") for t in getattr(entry, "tags", [])]
+        if "release" not in tags:
+            continue
+        link = entry.get("link", "")
+        m = _RELEASE_URL_RE.search(link)
+        if not m:
+            continue
+        minor = int(m.group(1))
+        date_struct = (
+            getattr(entry, "published_parsed", None)
+            or getattr(entry, "updated_parsed", None)
+        )
+        if date_struct:
+            feed_dates[minor] = datetime(*date_struct[:3]).strftime("%Y-%m-%d")
+
+    if not feed_dates:
+        raise ValueError("No release entries found in the VS Code Atom feed.")
+
+    return max(feed_dates.keys()), feed_dates
+
+
+def _extract_date_from_html(html: str) -> str | None:
+    """Try to extract an ISO-8601 date from VS Code release-notes HTML.
+
+    Checks (in order):
+    1. JSON-LD ``<script type="application/ld+json">`` with a ``datePublished`` key.
+    2. ``<meta property="article:published_time">`` tag.
+    """
+    soup = BeautifulSoup(html, "lxml")
+
+    # 1. JSON-LD structured data (most reliable)
+    for script in soup.find_all("script", type="application/ld+json"):
+        try:
+            data = json.loads(script.string or "")
+        except (json.JSONDecodeError, AttributeError):
+            continue
+        if isinstance(data, dict):
+            date_str = data.get("datePublished") or data.get("dateModified")
+            if date_str:
+                return str(date_str)[:10]
+
+    # 2. Open Graph / article meta tag
+    meta = soup.find("meta", attrs={"property": "article:published_time"})
+    if meta and meta.get("content"):
+        return str(meta["content"])[:10]
+
+    return None
+
+
+def fetch(ide_config: dict) -> list[dict]:
+    """Fetch all VS Code release notes from start_version to the latest.
+
+    For each minor version N in [start_minor, latest_minor]:
+    - Fetch ``https://code.visualstudio.com/updates/v1_N``.
+    - Extract ``<main>`` content and convert to Markdown.
+    - Determine the release date (feed first, then HTML meta, then skip gracefully).
+
+    Returns a list of release dicts conforming to the shared JSON schema.
+    Pages that return an HTTP error are warned about and skipped.
+    """
+    feed_url = ide_config.get("source_url", _FEED_URL)
+    start_version = ide_config.get("start_version", "1.75.0")
+    start_minor = _parse_minor_from_start_version(start_version)
+
+    feed_xml = get_text(feed_url, use_auth=False)
+    latest_minor, feed_dates = _parse_feed(feed_xml)
+
+    results: list[dict] = []
+    for n in range(start_minor, latest_minor + 1):
+        version = f"1.{n}.0"
+        page_url = _RELEASE_URL_TEMPLATE.format(n=n)
+
+        try:
+            html = get_text(page_url, use_auth=False)
+        except Exception as exc:  # noqa: BLE001
+            print(f"  [warn] Failed to fetch {page_url}: {exc}")
+            continue
+
+        # Extract <main> for body content (falls back to full body if absent).
+        soup = BeautifulSoup(html, "lxml")
+        main_tag = soup.find("main") or soup.find("article") or soup.body
+        body_html = str(main_tag) if main_tag else html
+
+        # Release date: feed (for recent entries) → HTML meta → skip with warning.
+        release_date: str | None = feed_dates.get(n) or _extract_date_from_html(html)
+        if not release_date:
+            print(f"  [warn] Could not determine release_date for {version}; skipping.")
+            continue
+
+        body_markdown = html_to_markdown(body_html)
+        copilot_mentions = extract_copilot_mentions(body_markdown)
+
+        title_tag = soup.find("title")
+        title = title_tag.get_text(strip=True) if title_tag else f"VS Code {version}"
+
+        results.append(
+            {
+                "ide": ide_config["id"],
+                "version": version,
+                "release_date": release_date,
+                "title": title,
+                "url": page_url,
+                "source": "feed",
+                "body_markdown": body_markdown,
+                "body_html": body_html,
+                "categories": [],
+                "copilot_mentions": copilot_mentions,
+            }
+        )
+
+    return results

--- a/tests/test_vs_code_fetcher.py
+++ b/tests/test_vs_code_fetcher.py
@@ -1,0 +1,309 @@
+"""Tests for scripts/fetchers/vs_code.py"""
+from unittest.mock import call, patch
+
+import pytest
+
+from scripts.fetchers.vs_code import (
+    _extract_date_from_html,
+    _parse_feed,
+    _parse_minor_from_start_version,
+    fetch,
+)
+
+_IDE_CONFIG = {
+    "id": "vs-code",
+    "name": "GitHub Copilot for VS Code",
+    "data_dir": "data/vs-code",
+    "fetcher": "vs_code",
+    "start_version": "1.75.0",
+    "source_url": "https://code.visualstudio.com/feed.xml",
+}
+
+# Minimal Atom feed XML with two release entries and one blog entry.
+# Uses <updated> (not <published>) to match the real VS Code feed format.
+_FAKE_FEED_XML = """\
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Visual Studio Code</title>
+  <entry>
+    <title>VS Code 1.76</title>
+    <link rel="alternate" href="https://code.visualstudio.com/updates/v1_76"/>
+    <category term="release"/>
+    <updated>2023-03-01T00:00:00Z</updated>
+  </entry>
+  <entry>
+    <title>VS Code 1.75</title>
+    <link rel="alternate" href="https://code.visualstudio.com/updates/v1_75"/>
+    <category term="release"/>
+    <updated>2023-02-01T00:00:00Z</updated>
+  </entry>
+  <entry>
+    <title>A blog post</title>
+    <link rel="alternate" href="https://code.visualstudio.com/blogs/2023/02/15/some-post"/>
+    <category term="blog"/>
+    <updated>2023-02-15T00:00:00Z</updated>
+  </entry>
+</feed>
+"""
+
+# Minimal HTML for a VS Code release-notes page with JSON-LD date.
+_FAKE_PAGE_HTML_76 = """\
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Visual Studio Code February 2023</title>
+  <script type="application/ld+json">
+  {"@context":"https://schema.org","@type":"Article","datePublished":"2023-03-01","headline":"Visual Studio Code March 2023"}
+  </script>
+</head>
+<body>
+  <main>
+    <h1>Visual Studio Code March 2023</h1>
+    <p>GitHub Copilot inline chat is now available.</p>
+  </main>
+</body>
+</html>
+"""
+
+# Minimal HTML for a page that uses <meta property="article:published_time">.
+_FAKE_PAGE_HTML_75 = """\
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Visual Studio Code January 2023</title>
+  <meta property="article:published_time" content="2023-02-01T00:00:00Z"/>
+</head>
+<body>
+  <main>
+    <h1>Visual Studio Code February 2023</h1>
+    <p>Copilot suggestions are faster in this release.</p>
+  </main>
+</body>
+</html>
+"""
+
+# HTML with no date information at all.
+_FAKE_PAGE_HTML_NO_DATE = """\
+<!DOCTYPE html>
+<html>
+<head><title>Some page</title></head>
+<body><main><p>Content here, no AI mentions.</p></main></body>
+</html>
+"""
+
+
+class TestParseMinorFromStartVersion:
+    def test_three_part_version(self):
+        assert _parse_minor_from_start_version("1.75.0") == 75
+
+    def test_two_part_version(self):
+        assert _parse_minor_from_start_version("1.90") == 90
+
+    def test_large_minor(self):
+        assert _parse_minor_from_start_version("1.100.0") == 100
+
+    def test_invalid_single_part_raises(self):
+        with pytest.raises(ValueError, match="Cannot extract minor"):
+            _parse_minor_from_start_version("1")
+
+
+class TestParseFeed:
+    def test_returns_latest_minor(self):
+        latest_minor, _ = _parse_feed(_FAKE_FEED_XML)
+        assert latest_minor == 76
+
+    def test_returns_feed_dates(self):
+        _, feed_dates = _parse_feed(_FAKE_FEED_XML)
+        assert 75 in feed_dates
+        assert 76 in feed_dates
+        assert feed_dates[75] == "2023-02-01"
+        assert feed_dates[76] == "2023-03-01"
+
+    def test_blog_entries_are_excluded(self):
+        _, feed_dates = _parse_feed(_FAKE_FEED_XML)
+        # No entry for a blog URL should appear (blog entry has no /updates/v1_N link)
+        assert len(feed_dates) == 2
+
+    def test_no_release_entries_raises(self):
+        blog_only_feed = """\
+<?xml version="1.0"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <entry>
+    <link href="https://code.visualstudio.com/blog/2023/01/01/some-blog"/>
+    <category term="blog"/>
+    <updated>2023-01-01T00:00:00Z</updated>
+  </entry>
+</feed>
+"""
+        with pytest.raises(ValueError, match="No release entries found"):
+            _parse_feed(blog_only_feed)
+
+    def test_updated_field_used_when_no_published(self):
+        """Feed entries that only have <updated> (no <published>) still yield a date."""
+        feed_with_updated_only = """\
+<?xml version="1.0"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <entry>
+    <link rel="alternate" href="https://code.visualstudio.com/updates/v1_80"/>
+    <category term="release"/>
+    <updated>2023-08-01T00:00:00Z</updated>
+  </entry>
+</feed>
+"""
+        latest, dates = _parse_feed(feed_with_updated_only)
+        assert latest == 80
+        assert dates[80] == "2023-08-01"
+
+
+class TestExtractDateFromHtml:
+    def test_json_ld_date(self):
+        assert _extract_date_from_html(_FAKE_PAGE_HTML_76) == "2023-03-01"
+
+    def test_meta_article_published_time(self):
+        assert _extract_date_from_html(_FAKE_PAGE_HTML_75) == "2023-02-01"
+
+    def test_returns_none_when_no_date(self):
+        assert _extract_date_from_html(_FAKE_PAGE_HTML_NO_DATE) is None
+
+    def test_json_ld_date_truncated_to_10_chars(self):
+        html = """\
+<html><head>
+<script type="application/ld+json">{"datePublished": "2023-03-01T12:00:00Z"}</script>
+</head><body></body></html>"""
+        assert _extract_date_from_html(html) == "2023-03-01"
+
+
+class TestFetch:
+    def _make_get_text_side_effect(self, pages: dict[str, str]):
+        """Return a side-effect function that dispatches by URL."""
+        def side_effect(url, *, use_auth=True):
+            if url not in pages:
+                raise ValueError(f"Unexpected URL in test: {url}")
+            return pages[url]
+        return side_effect
+
+    def test_returns_one_record_per_version_in_range(self):
+        pages = {
+            "https://code.visualstudio.com/feed.xml": _FAKE_FEED_XML,
+            "https://code.visualstudio.com/updates/v1_75": _FAKE_PAGE_HTML_75,
+            "https://code.visualstudio.com/updates/v1_76": _FAKE_PAGE_HTML_76,
+        }
+        with patch("scripts.fetchers.vs_code.get_text", side_effect=self._make_get_text_side_effect(pages)):
+            results = fetch(_IDE_CONFIG)
+
+        assert len(results) == 2
+        versions = {r["version"] for r in results}
+        assert versions == {"1.75.0", "1.76.0"}
+
+    def test_record_fields_are_populated(self):
+        pages = {
+            "https://code.visualstudio.com/feed.xml": _FAKE_FEED_XML,
+            "https://code.visualstudio.com/updates/v1_75": _FAKE_PAGE_HTML_75,
+            "https://code.visualstudio.com/updates/v1_76": _FAKE_PAGE_HTML_76,
+        }
+        with patch("scripts.fetchers.vs_code.get_text", side_effect=self._make_get_text_side_effect(pages)):
+            results = fetch(_IDE_CONFIG)
+
+        r75 = next(r for r in results if r["version"] == "1.75.0")
+        assert r75["ide"] == "vs-code"
+        assert r75["release_date"] == "2023-02-01"
+        assert r75["url"] == "https://code.visualstudio.com/updates/v1_75"
+        assert r75["source"] == "feed"
+        assert r75["title"] == "Visual Studio Code January 2023"
+        assert r75["body_markdown"] != ""
+        assert isinstance(r75["categories"], list)
+        assert isinstance(r75["copilot_mentions"], list)
+
+    def test_copilot_mentions_populated(self):
+        pages = {
+            "https://code.visualstudio.com/feed.xml": _FAKE_FEED_XML,
+            "https://code.visualstudio.com/updates/v1_75": _FAKE_PAGE_HTML_75,
+            "https://code.visualstudio.com/updates/v1_76": _FAKE_PAGE_HTML_76,
+        }
+        with patch("scripts.fetchers.vs_code.get_text", side_effect=self._make_get_text_side_effect(pages)):
+            results = fetch(_IDE_CONFIG)
+
+        # Both pages reference Copilot in body text.
+        for r in results:
+            assert len(r["copilot_mentions"]) > 0, f"No copilot_mentions for {r['version']}"
+
+    def test_feed_date_used_for_recent_versions(self):
+        """Versions present in the feed get their date from the feed, not the page."""
+        pages = {
+            "https://code.visualstudio.com/feed.xml": _FAKE_FEED_XML,
+            "https://code.visualstudio.com/updates/v1_75": _FAKE_PAGE_HTML_75,
+            "https://code.visualstudio.com/updates/v1_76": _FAKE_PAGE_HTML_76,
+        }
+        with patch("scripts.fetchers.vs_code.get_text", side_effect=self._make_get_text_side_effect(pages)):
+            results = fetch(_IDE_CONFIG)
+
+        r76 = next(r for r in results if r["version"] == "1.76.0")
+        # Feed date is 2023-03-01; page JSON-LD also says 2023-03-01 for this test.
+        assert r76["release_date"] == "2023-03-01"
+
+    def test_page_with_no_date_is_skipped(self):
+        """Versions where neither feed nor HTML yields a date are skipped."""
+        feed_xml_no_date = """\
+<?xml version="1.0"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <entry>
+    <link rel="alternate" href="https://code.visualstudio.com/updates/v1_76"/>
+    <category term="release"/>
+    <updated>2023-03-01T00:00:00Z</updated>
+  </entry>
+</feed>
+"""
+        pages = {
+            "https://code.visualstudio.com/feed.xml": feed_xml_no_date,
+            "https://code.visualstudio.com/updates/v1_75": _FAKE_PAGE_HTML_NO_DATE,
+            "https://code.visualstudio.com/updates/v1_76": _FAKE_PAGE_HTML_76,
+        }
+        with patch("scripts.fetchers.vs_code.get_text", side_effect=self._make_get_text_side_effect(pages)):
+            results = fetch(_IDE_CONFIG)
+
+        # v1_75 has no date in feed and no date in HTML → skipped.
+        versions = {r["version"] for r in results}
+        assert "1.75.0" not in versions
+        assert "1.76.0" in versions
+
+    def test_http_error_skips_version(self):
+        """Pages that raise HTTP errors are skipped with a warning."""
+        def side_effect(url, *, use_auth=True):
+            if "feed.xml" in url:
+                return _FAKE_FEED_XML
+            if "v1_75" in url:
+                raise Exception("HTTP 404")
+            return _FAKE_PAGE_HTML_76
+
+        with patch("scripts.fetchers.vs_code.get_text", side_effect=side_effect):
+            results = fetch(_IDE_CONFIG)
+
+        versions = {r["version"] for r in results}
+        assert "1.75.0" not in versions
+        assert "1.76.0" in versions
+
+    def test_uses_custom_source_url(self):
+        """fetch() uses ide_config source_url instead of the default."""
+        custom_config = {**_IDE_CONFIG, "source_url": "https://custom.example.com/feed.xml"}
+        pages = {
+            "https://custom.example.com/feed.xml": _FAKE_FEED_XML,
+            "https://code.visualstudio.com/updates/v1_75": _FAKE_PAGE_HTML_75,
+            "https://code.visualstudio.com/updates/v1_76": _FAKE_PAGE_HTML_76,
+        }
+        with patch("scripts.fetchers.vs_code.get_text", side_effect=self._make_get_text_side_effect(pages)):
+            results = fetch(custom_config)
+
+        assert len(results) == 2
+
+    def test_start_version_respected(self):
+        """Only versions >= start_version are fetched."""
+        config_76_start = {**_IDE_CONFIG, "start_version": "1.76.0"}
+        pages = {
+            "https://code.visualstudio.com/feed.xml": _FAKE_FEED_XML,
+            "https://code.visualstudio.com/updates/v1_76": _FAKE_PAGE_HTML_76,
+        }
+        with patch("scripts.fetchers.vs_code.get_text", side_effect=self._make_get_text_side_effect(pages)):
+            results = fetch(config_76_start)
+
+        assert len(results) == 1
+        assert results[0]["version"] == "1.76.0"


### PR DESCRIPTION
This pull request adds support for fetching and processing release notes for GitHub Copilot for VS Code. It introduces a new fetcher script, integrates VS Code into the configuration, sets up automated fetching via GitHub Actions, and provides comprehensive tests for the new fetcher.

**VS Code Release Notes Fetching and Integration:**

* Added a new fetcher script `vs_code.py` to `scripts/fetchers/` that scrapes and processes VS Code release notes, extracting Copilot mentions and relevant metadata.
* Registered VS Code as a supported IDE in `config/ides.yml`, including its fetcher configuration and data directory.

**Automation and Testing:**

* Introduced a new GitHub Actions workflow `.github/workflows/fetch-vs-code.yml` to automatically fetch and commit new VS Code release notes daily.
* Added comprehensive unit tests for the VS Code fetcher in `tests/test_vs_code_fetcher.py`, covering parsing, extraction, error handling, and integration with the fetch workflow.