### PR TITLE
Implemented MVP 5 and fixed magic strings

### DIFF
--- a/.github/workflows/fetch-visual-studio-2026.yml
+++ b/.github/workflows/fetch-visual-studio-2026.yml
@@ -1,0 +1,60 @@
+name: Fetch Visual Studio 2026 release notes
+
+on:
+  schedule:
+    - cron: '41 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  fetch:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Fetch Visual Studio 2026 release notes
+        run: python -m scripts.run --ide visual-studio-2026
+
+      - name: Commit new files
+        if: github.ref == 'refs/heads/main'
+        id: create-pr
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          add-paths: data/visual-studio-2026/
+          commit-message: "chore(visual-studio-2026): add new release notes"
+          branch: bot/fetch-visual-studio-2026
+          delete-branch: true
+          title: "chore(visual-studio-2026): add new release notes"
+          body: "Automated update: new Visual Studio 2026 release notes fetched by the daily workflow."
+
+      - name: Enable auto-merge
+        if: github.ref == 'refs/heads/main' && steps.create-pr.outputs.pull-request-number != ''
+        run: gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-number }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Simulate commit (non-default branch)
+        if: github.ref != 'refs/heads/main'
+        run: |
+          git add data/visual-studio-2026/
+          if git diff --staged --quiet; then
+            echo "No new releases - nothing to commit."
+          else
+            echo "Running on non-default branch (${{ github.ref_name }}) - skipping commit."
+            echo "Files that would have been committed:"
+            git diff --staged --name-only
+          fi

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ scripts/fetchers/        – one module per IDE
 tests/                   – pytest test suite
 ```
 
+Fetcher endpoints are configured centrally in [config/ides.yml](config/ides.yml), including `source_url` and any per-IDE URL templates or canonical plugin URLs needed by a fetcher.
+
 ## Supported IDEs
 
 | ID | Name |
@@ -21,6 +23,8 @@ tests/                   – pytest test suite
 | `jetbrains` | GitHub Copilot for JetBrains |
 | `xcode` | GitHub Copilot for Xcode |
 | `vim-neovim` | GitHub Copilot for Vim/Neovim |
+| `vs-code` | GitHub Copilot for VS Code |
+| `visual-studio-2026` | Visual Studio 2026 |
 
 ## Running a fetcher locally
 

--- a/config/ides.yml
+++ b/config/ides.yml
@@ -18,6 +18,7 @@ ides:
     fetcher: jetbrains
     start_version: all
     source_url: https://plugins.jetbrains.com/api/plugins/17718/updates
+    plugin_url: https://plugins.jetbrains.com/plugin/17718-github-copilot/versions
 
   - id: xcode
     name: GitHub Copilot for Xcode
@@ -38,8 +39,15 @@ ides:
     fetcher: vs_code
     start_version: "1.75.0"
     source_url: https://code.visualstudio.com/feed.xml
+    release_url_template: https://code.visualstudio.com/updates/v1_{n}
+
+  - id: visual-studio-2026
+    name: Visual Studio 2026
+    data_dir: data/visual-studio-2026
+    fetcher: visual_studio
+    start_version: "17.14.0"
+    source_url: https://learn.microsoft.com/en-us/visualstudio/releases/2026/release-notes
 
   # Real IDE entries will be added in subsequent MVPs:
   # - id: visual-studio-2022
-  # - id: visual-studio-2026
   # - id: sql-server-management-studio

--- a/scripts/common/config.py
+++ b/scripts/common/config.py
@@ -17,3 +17,12 @@ def get_ide_config(ide_id: str, config_path: pathlib.Path = _CONFIG_PATH) -> dic
         if ide["id"] == ide_id:
             return ide
     raise ValueError(f"IDE '{ide_id}' not found in {config_path}")
+
+
+def require_config_value(ide_config: dict, key: str) -> str:
+    """Return a required non-empty config value for an IDE."""
+    value = ide_config.get(key)
+    if value is None or (isinstance(value, str) and not value.strip()):
+        ide_id = ide_config.get("id", "<unknown>")
+        raise ValueError(f"IDE '{ide_id}' is missing required config value '{key}'")
+    return value

--- a/scripts/common/html_split.py
+++ b/scripts/common/html_split.py
@@ -1,0 +1,71 @@
+"""Helpers for splitting large HTML release-notes pages into per-version sections."""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime
+
+from bs4 import BeautifulSoup, Tag
+
+
+def normalize_human_date(date_text: str) -> str:
+    """Convert a date like 'April 21st, 2026' to ISO-8601."""
+    cleaned = re.sub(r"(\d{1,2})(st|nd|rd|th)", r"\1", date_text.strip(), flags=re.IGNORECASE)
+    return datetime.strptime(cleaned, "%B %d, %Y").strftime("%Y-%m-%d")
+
+
+def split_version_sections(
+    html: str,
+    *,
+    heading_tags: tuple[str, ...],
+    version_pattern: str,
+    date_pattern: str,
+) -> list[dict[str, str]]:
+    """Split a release-notes page into version sections.
+
+    Each matching heading starts a section. The section body includes all sibling
+    nodes up to the next matching heading.
+    """
+    soup = BeautifulSoup(html, "lxml")
+    version_re = re.compile(version_pattern, re.IGNORECASE)
+    date_re = re.compile(date_pattern, re.IGNORECASE)
+
+    sections: list[dict[str, str]] = []
+
+    for heading in soup.find_all(heading_tags):
+        if not isinstance(heading, Tag):
+            continue
+
+        heading_text = heading.get_text(" ", strip=True)
+        version_match = version_re.search(heading_text)
+        if not version_match:
+            continue
+
+        body_parts: list[str] = []
+        date_match = None
+        for sibling in heading.next_siblings:
+            if isinstance(sibling, Tag) and sibling.name in heading_tags:
+                sibling_text = sibling.get_text(" ", strip=True)
+                if version_re.search(sibling_text):
+                    break
+
+            if isinstance(sibling, Tag):
+                body_parts.append(str(sibling))
+                if date_match is None:
+                    date_match = date_re.search(sibling.get_text(" ", strip=True))
+
+        if date_match is None:
+            date_match = date_re.search(heading_text)
+        if date_match is None:
+            raise ValueError(f"Could not find release date for section {heading_text!r}")
+
+        sections.append(
+            {
+                "version": version_match.group("version"),
+                "title": heading_text,
+                "release_date": normalize_human_date(date_match.group("date")),
+                "body_html": "\n".join(body_parts).strip(),
+            }
+        )
+
+    return sections

--- a/scripts/fetchers/copilot_vim.py
+++ b/scripts/fetchers/copilot_vim.py
@@ -3,12 +3,9 @@ import re
 
 from bs4 import BeautifulSoup, Tag
 
+from scripts.common.config import require_config_value
 from scripts.common.extract import extract_copilot_mentions
 from scripts.common.http import get_text
-
-_FEATURE_MATRIX_URL = (
-    "https://docs.github.com/en/copilot/reference/copilot-feature-matrix?tool=vimneovim"
-)
 
 # (heading text on the page, version key for the JSON file, approximate release date)
 _SECTIONS: list[tuple[str, str, str]] = [
@@ -23,14 +20,15 @@ _HEADING_RE = re.compile(r"^h[1-6]$")
 
 
 def fetch(ide_config: dict) -> list[dict]:
-    source_url = ide_config.get("source_url", _FEATURE_MATRIX_URL)
+    source_url = require_config_value(ide_config, "source_url")
     html = get_text(source_url, use_auth=False)
     return _parse_feature_matrix(ide_config, html, source_url=source_url)
 
 
 def _parse_feature_matrix(
-    ide_config: dict, html: str, *, source_url: str = _FEATURE_MATRIX_URL
+    ide_config: dict, html: str, *, source_url: str | None = None
 ) -> list[dict]:
+    source_url = source_url or require_config_value(ide_config, "source_url")
     soup = BeautifulSoup(html, "lxml")
     results = []
 
@@ -68,13 +66,14 @@ def _extract_plugin_versions(
     era_key: str,
     release_date: str,
     *,
-    source_url: str = _FEATURE_MATRIX_URL,
+    source_url: str | None = None,
 ) -> list[dict]:
     """Return one record per plugin-version column found in the table header.
 
     Only features whose cell value is not ✗ (i.e. supported or partially
     supported) are included in the record's body_markdown.
     """
+    source_url = source_url or require_config_value(ide_config, "source_url")
     rows = table.find_all("tr")
     if not rows:
         return []

--- a/scripts/fetchers/eclipse.py
+++ b/scripts/fetchers/eclipse.py
@@ -5,11 +5,11 @@ Title format: "0.16.0 - 20260403"  →  version=0.16.0, release_date=2026-04-03
 """
 import re
 
+from scripts.common.config import require_config_value
 from scripts.common.extract import extract_copilot_mentions, html_to_markdown
 from scripts.common.github_releases import paginate_github_releases
 from scripts.common.http import get_json
 
-_API_URL = "https://api.github.com/repos/microsoft/copilot-for-eclipse/releases"
 _TITLE_RE = re.compile(r"^(?P<version>\d+\.\d+\.\d+)\s*-\s*(?P<date>\d{8})$")
 
 
@@ -25,7 +25,7 @@ def _parse_title(title: str) -> tuple[str, str]:
 
 def fetch(ide_config: dict) -> list[dict]:
     """Fetch all Copilot for Eclipse releases and return a list of release dicts."""
-    releases_api_url = ide_config.get("source_url", _API_URL)
+    releases_api_url = require_config_value(ide_config, "source_url")
     raw_releases = paginate_github_releases(releases_api_url, get_json_fn=get_json)
     results: list[dict] = []
 

--- a/scripts/fetchers/jetbrains.py
+++ b/scripts/fetchers/jetbrains.py
@@ -14,15 +14,14 @@ We group them into one JSON file per semver with a `builds[]` array.
 import re
 from datetime import datetime, timezone
 
+from scripts.common.config import require_config_value
 from scripts.common.extract import extract_copilot_mentions, html_to_markdown
 from scripts.common.http import get_json
 
-_API_URL = "https://plugins.jetbrains.com/api/plugins/17718/updates"
 # Matches "X.Y.Z-NNN" or "X.Y.Z.NNNN-NNN" (3-part or 4-part + build suffix).
 _VERSION_RE = re.compile(r"^(?P<semver>\d+(?:\.\d+){2,3})-(?P<build>\d+)$")
 # Matches "X.Y.Z..." (3 or more parts, no build suffix — legacy universal releases).
 _VERSION_NO_BUILD_RE = re.compile(r"^(?P<semver>\d+(?:\.\d+){2,})$")
-_PLUGIN_URL = "https://plugins.jetbrains.com/plugin/17718-github-copilot/versions"
 
 
 def _parse_version(version_str: str) -> tuple[str, str | None]:
@@ -44,7 +43,7 @@ def _parse_version(version_str: str) -> tuple[str, str | None]:
     raise ValueError(f"Unrecognised JetBrains version string: {version_str!r}")
 
 
-def _paginate_updates() -> list[dict]:
+def _paginate_updates(api_url: str) -> list[dict]:
     """Return all plugin update objects from the JetBrains Marketplace API.
 
     Deduplicates by entry ``id`` because the API can return the same entry on
@@ -54,7 +53,7 @@ def _paginate_updates() -> list[dict]:
     updates: list[dict] = []
     page = 0
     while True:
-        page_data = get_json(_API_URL, params={"size": 100, "page": page}, use_auth=False)
+        page_data = get_json(api_url, params={"size": 100, "page": page}, use_auth=False)
         if not page_data:
             break
         for item in page_data:
@@ -73,7 +72,9 @@ def fetch(ide_config: dict) -> list[dict]:
     ``1.5.62``) and contains a ``builds[]`` sub-array with per-IDE-build
     compatibility metadata.
     """
-    raw_updates = _paginate_updates()
+    api_url = require_config_value(ide_config, "source_url")
+    plugin_url = require_config_value(ide_config, "plugin_url")
+    raw_updates = _paginate_updates(api_url)
 
     # Group raw update entries by semantic version.
     groups: dict[str, list[dict]] = {}
@@ -124,7 +125,7 @@ def fetch(ide_config: dict) -> list[dict]:
                 "version": semver,
                 "release_date": release_date,
                 "title": f"GitHub Copilot for JetBrains {semver}",
-                "url": _PLUGIN_URL,
+                "url": plugin_url,
                 "source": "api",
                 "body_markdown": notes_markdown,
                 "body_html": notes_html,

--- a/scripts/fetchers/visual_studio.py
+++ b/scripts/fetchers/visual_studio.py
@@ -1,0 +1,55 @@
+"""Visual Studio release-notes fetcher for learn.microsoft.com HTML pages."""
+
+from __future__ import annotations
+
+from packaging.version import Version
+
+from scripts.common.config import require_config_value
+from scripts.common.extract import extract_copilot_mentions, html_to_markdown
+from scripts.common.html_split import split_version_sections
+from scripts.common.http import get_text
+
+
+def _is_at_or_above_start_version(version: str, start_version: str | None) -> bool:
+    if not start_version or start_version == "all":
+        return True
+    return Version(version) >= Version(start_version)
+
+
+def fetch(ide_config: dict) -> list[dict]:
+    """Fetch Visual Studio 2026 release notes from the unified HTML page."""
+    source_url = require_config_value(ide_config, "source_url")
+    start_version = ide_config.get("start_version")
+
+    html = get_text(source_url, use_auth=False)
+    sections = split_version_sections(
+        html,
+        heading_tags=("h2",),
+        version_pattern=r"^Version\s+(?P<version>\d+\.\d+\.\d+)$",
+        date_pattern=r"Released(?:\s+on)?\s+(?P<date>[A-Za-z]+\s+\d{1,2}(?:st|nd|rd|th)?,\s+\d{4})",
+    )
+
+    results: list[dict] = []
+    for section in sections:
+        version = section["version"]
+        if not _is_at_or_above_start_version(version, start_version):
+            continue
+
+        body_html = section["body_html"]
+        body_markdown = html_to_markdown(body_html)
+        results.append(
+            {
+                "ide": ide_config["id"],
+                "version": version,
+                "release_date": section["release_date"],
+                "title": section["title"],
+                "url": source_url,
+                "source": "html",
+                "body_markdown": body_markdown,
+                "body_html": body_html,
+                "categories": [],
+                "copilot_mentions": extract_copilot_mentions(body_markdown),
+            }
+        )
+
+    return results

--- a/scripts/fetchers/vs_code.py
+++ b/scripts/fetchers/vs_code.py
@@ -19,11 +19,10 @@ from datetime import datetime
 import feedparser
 from bs4 import BeautifulSoup
 
+from scripts.common.config import require_config_value
 from scripts.common.extract import extract_copilot_mentions, html_to_markdown
 from scripts.common.http import get_text
 
-_FEED_URL = "https://code.visualstudio.com/feed.xml"
-_RELEASE_URL_TEMPLATE = "https://code.visualstudio.com/updates/v1_{n}"
 # Matches the minor version in VS Code release-notes URLs (/updates/v1_75).
 _RELEASE_URL_RE = re.compile(r"/updates/v1_(\d+)")
 
@@ -114,8 +113,9 @@ def fetch(ide_config: dict) -> list[dict]:
     Returns a list of release dicts conforming to the shared JSON schema.
     Pages that return an HTTP error are warned about and skipped.
     """
-    feed_url = ide_config.get("source_url", _FEED_URL)
-    start_version = ide_config.get("start_version", "1.75.0")
+    feed_url = require_config_value(ide_config, "source_url")
+    release_url_template = require_config_value(ide_config, "release_url_template")
+    start_version = require_config_value(ide_config, "start_version")
     start_minor = _parse_minor_from_start_version(start_version)
 
     feed_xml = get_text(feed_url, use_auth=False)
@@ -124,7 +124,7 @@ def fetch(ide_config: dict) -> list[dict]:
     results: list[dict] = []
     for n in range(start_minor, latest_minor + 1):
         version = f"1.{n}.0"
-        page_url = _RELEASE_URL_TEMPLATE.format(n=n)
+        page_url = release_url_template.format(n=n)
 
         try:
             html = get_text(page_url, use_auth=False)

--- a/scripts/fetchers/xcode.py
+++ b/scripts/fetchers/xcode.py
@@ -3,12 +3,9 @@ import re
 
 from bs4 import BeautifulSoup, Tag
 
+from scripts.common.config import require_config_value
 from scripts.common.extract import extract_copilot_mentions
 from scripts.common.http import get_text
-
-_FEATURE_MATRIX_URL = (
-    "https://docs.github.com/en/copilot/reference/copilot-feature-matrix?tool=xcode"
-)
 
 # (heading text on the page, version key for the JSON file, approximate release date)
 _SECTIONS: list[tuple[str, str, str]] = [
@@ -21,14 +18,15 @@ _HEADING_RE = re.compile(r"^h[1-6]$")
 
 
 def fetch(ide_config: dict) -> list[dict]:
-    source_url = ide_config.get("source_url", _FEATURE_MATRIX_URL)
+    source_url = require_config_value(ide_config, "source_url")
     html = get_text(source_url, use_auth=False)
     return _parse_feature_matrix(ide_config, html, source_url=source_url)
 
 
 def _parse_feature_matrix(
-    ide_config: dict, html: str, *, source_url: str = _FEATURE_MATRIX_URL
+    ide_config: dict, html: str, *, source_url: str | None = None
 ) -> list[dict]:
+    source_url = source_url or require_config_value(ide_config, "source_url")
     soup = BeautifulSoup(html, "lxml")
     results = []
 
@@ -66,13 +64,14 @@ def _extract_plugin_versions(
     era_key: str,
     release_date: str,
     *,
-    source_url: str = _FEATURE_MATRIX_URL,
+    source_url: str | None = None,
 ) -> list[dict]:
     """Return one record per plugin-version column found in the table header.
 
     Only features whose cell value is not ✗ (i.e. supported or partially
     supported) are included in the record's body_markdown.
     """
+    source_url = source_url or require_config_value(ide_config, "source_url")
     rows = table.find_all("tr")
     if not rows:
         return []

--- a/tests/test_copilot_vim_fetcher.py
+++ b/tests/test_copilot_vim_fetcher.py
@@ -1,10 +1,10 @@
 """Tests for scripts/fetchers/copilot_vim.py."""
 from unittest.mock import patch
 
+import pytest
 from bs4 import BeautifulSoup
 
 from scripts.fetchers.copilot_vim import (
-    _FEATURE_MATRIX_URL,
     _extract_plugin_versions,
     _find_next_table,
     _find_section_heading,
@@ -18,6 +18,7 @@ _IDE_CONFIG = {
     "name": "GitHub Copilot for Vim/Neovim",
     "data_dir": "data/vim-neovim",
     "fetcher": "copilot_vim",
+    "source_url": "https://docs.github.com/en/copilot/reference/copilot-feature-matrix?tool=vimneovim",
 }
 
 # Minimal HTML that mirrors the real docs page structure.
@@ -244,10 +245,12 @@ class TestFetch:
             fetch(config)
         mock_get.assert_called_once_with("https://custom.example/matrix", use_auth=False)
 
-    def test_falls_back_to_default_url(self):
-        with patch("scripts.fetchers.copilot_vim.get_text", return_value=_FAKE_HTML) as mock_get:
-            fetch(_IDE_CONFIG)
-        mock_get.assert_called_once_with(_FEATURE_MATRIX_URL, use_auth=False)
+    def test_missing_source_url_raises(self):
+        config = dict(_IDE_CONFIG)
+        config.pop("source_url")
+        with patch("scripts.fetchers.copilot_vim.get_text"):
+            with pytest.raises(ValueError, match="missing required config value 'source_url'"):
+                fetch(config)
 
     def test_returns_list_of_dicts(self):
         with patch("scripts.fetchers.copilot_vim.get_text", return_value=_FAKE_HTML):

--- a/tests/test_eclipse_fetcher.py
+++ b/tests/test_eclipse_fetcher.py
@@ -11,6 +11,7 @@ _IDE_CONFIG = {
     "data_dir": "data/eclipse",
     "fetcher": "eclipse",
     "start_version": "all",
+    "source_url": "https://api.github.com/repos/microsoft/copilot-for-eclipse/releases",
 }
 
 _FAKE_RELEASES = [
@@ -138,3 +139,9 @@ class TestFetch:
         with patch("scripts.fetchers.eclipse.get_json", side_effect=[[], []]) as mock_get_json:
             fetch(config)
         assert mock_get_json.call_args_list[0].args[0] == "https://custom.example/releases"
+
+    def test_missing_source_url_raises(self):
+        config = dict(_IDE_CONFIG)
+        config.pop("source_url")
+        with pytest.raises(ValueError, match="missing required config value 'source_url'"):
+            fetch(config)

--- a/tests/test_html_split.py
+++ b/tests/test_html_split.py
@@ -1,0 +1,57 @@
+"""Tests for scripts/common/html_split.py."""
+
+import pytest
+
+from scripts.common.html_split import normalize_human_date, split_version_sections
+
+_FAKE_HTML = """\
+<html>
+<body>
+  <h2>Version 17.14.31</h2>
+    <p>Released on April 21th, 2026.</p>
+  <div><h3>Highlights</h3><p>GitHub Copilot chat improvements.</p></div>
+  <h2>Version 17.14.1</h2>
+    <p>Released on January 15th, 2026.</p>
+  <div><p>Servicing fixes.</p></div>
+</body>
+</html>
+"""
+
+
+class TestNormalizeHumanDate:
+    def test_strips_ordinal_suffixes(self):
+        assert normalize_human_date("April 21st, 2026") == "2026-04-21"
+
+    def test_handles_typo_like_21th(self):
+        assert normalize_human_date("April 21th, 2026") == "2026-04-21"
+
+
+class TestSplitVersionSections:
+    def test_returns_one_section_per_matching_heading(self):
+        sections = split_version_sections(
+            _FAKE_HTML,
+            heading_tags=("h2",),
+            version_pattern=r"^Version\s+(?P<version>\d+\.\d+\.\d+)$",
+            date_pattern=r"Released(?:\s+on)?\s+(?P<date>[A-Za-z]+\s+\d{1,2}(?:st|nd|rd|th)?,\s+\d{4})",
+        )
+        assert [section["version"] for section in sections] == ["17.14.31", "17.14.1"]
+
+    def test_keeps_nested_content_inside_section_body(self):
+        sections = split_version_sections(
+            _FAKE_HTML,
+            heading_tags=("h2",),
+            version_pattern=r"^Version\s+(?P<version>\d+\.\d+\.\d+)$",
+            date_pattern=r"Released(?:\s+on)?\s+(?P<date>[A-Za-z]+\s+\d{1,2}(?:st|nd|rd|th)?,\s+\d{4})",
+        )
+        assert "GitHub Copilot chat improvements." in sections[0]["body_html"]
+        assert "Servicing fixes." not in sections[0]["body_html"]
+
+    def test_raises_when_date_missing(self):
+        html = "<html><body><h2>Version 17.14.31</h2><p>No date here</p></body></html>"
+        with pytest.raises(ValueError, match="Could not find release date"):
+            split_version_sections(
+                html,
+                heading_tags=("h2",),
+                version_pattern=r"^Version\s+(?P<version>\d+\.\d+\.\d+)$",
+                date_pattern=r"Released(?:\s+on)?\s+(?P<date>[A-Za-z]+\s+\d{1,2}(?:st|nd|rd|th)?,\s+\d{4})",
+            )

--- a/tests/test_jetbrains_fetcher.py
+++ b/tests/test_jetbrains_fetcher.py
@@ -11,6 +11,8 @@ _IDE_CONFIG = {
     "data_dir": "data/jetbrains",
     "fetcher": "jetbrains",
     "start_version": "all",
+    "source_url": "https://plugins.jetbrains.com/api/plugins/17718/updates",
+    "plugin_url": "https://plugins.jetbrains.com/plugin/17718-github-copilot/versions",
 }
 
 # Fake API update entries (two builds for 1.5.62, one for 1.5.63)
@@ -257,6 +259,17 @@ class TestFetch:
     def test_empty_api_returns_empty_list(self):
         releases = self._run_fetch([[]])
         assert releases == []
+
+    def test_result_url_comes_from_config(self):
+        releases = self._run_fetch([_FAKE_UPDATES_PAGE1, []])
+        assert all(r["url"] == _IDE_CONFIG["plugin_url"] for r in releases)
+
+    def test_missing_plugin_url_raises(self):
+        config = dict(_IDE_CONFIG)
+        config.pop("plugin_url")
+        with pytest.raises(ValueError, match="missing required config value 'plugin_url'"):
+            with patch("scripts.fetchers.jetbrains.get_json", return_value=[]):
+                fetch(config)
 
     def test_builds_contain_since_and_until(self):
         releases = self._run_fetch([_FAKE_UPDATES_PAGE1, []])

--- a/tests/test_visual_studio_fetcher.py
+++ b/tests/test_visual_studio_fetcher.py
@@ -1,0 +1,84 @@
+"""Tests for scripts/fetchers/visual_studio.py."""
+
+from unittest.mock import patch
+
+import pytest
+
+from scripts.fetchers.visual_studio import _is_at_or_above_start_version, fetch
+
+_IDE_CONFIG = {
+    "id": "visual-studio-2026",
+    "name": "Visual Studio 2026",
+    "data_dir": "data/visual-studio-2026",
+    "fetcher": "visual_studio",
+    "start_version": "17.14.0",
+    "source_url": "https://learn.microsoft.com/en-us/visualstudio/releases/2026/release-notes",
+}
+
+_FAKE_HTML = """\
+<!DOCTYPE html>
+<html>
+<body>
+  <h2>Version 17.13.9</h2>
+    <p>Released on December 12th, 2025.</p>
+  <div><p>Older content.</p></div>
+
+  <h2>Version 17.14.1</h2>
+    <p>Released on January 15th, 2026.</p>
+  <div>
+    <h3>What's new</h3>
+    <p>GitHub Copilot agent mode is now included.</p>
+  </div>
+
+  <h2>Version 17.14.31</h2>
+    <p>Released on April 21th, 2026.</p>
+  <div>
+    <h3>Improvements</h3>
+    <p>GitHub Copilot chat fixes and performance updates.</p>
+  </div>
+</body>
+</html>
+"""
+
+
+class TestStartVersionFilter:
+    def test_version_equal_to_floor_is_included(self):
+        assert _is_at_or_above_start_version("17.14.0", "17.14.0") is True
+
+    def test_version_below_floor_is_excluded(self):
+        assert _is_at_or_above_start_version("17.13.9", "17.14.0") is False
+
+
+class TestFetch:
+    def test_returns_one_record_per_matching_section_at_or_above_start_version(self):
+        with patch("scripts.fetchers.visual_studio.get_text", return_value=_FAKE_HTML):
+            results = fetch(_IDE_CONFIG)
+
+        assert [record["version"] for record in results] == ["17.14.1", "17.14.31"]
+
+    def test_record_fields_are_populated(self):
+        with patch("scripts.fetchers.visual_studio.get_text", return_value=_FAKE_HTML):
+            results = fetch(_IDE_CONFIG)
+
+        record = next(item for item in results if item["version"] == "17.14.31")
+        assert record["ide"] == "visual-studio-2026"
+        assert record["release_date"] == "2026-04-21"
+        assert record["title"] == "Version 17.14.31"
+        assert record["url"] == _IDE_CONFIG["source_url"]
+        assert record["source"] == "html"
+        assert "GitHub Copilot chat fixes" in record["body_markdown"]
+        assert len(record["copilot_mentions"]) == 1
+
+    def test_uses_source_url_from_config(self):
+        config = {**_IDE_CONFIG, "source_url": "https://example.test/visual-studio-2026"}
+        with patch("scripts.fetchers.visual_studio.get_text", return_value=_FAKE_HTML) as mock_get_text:
+            fetch(config)
+
+        assert mock_get_text.call_args.args[0] == "https://example.test/visual-studio-2026"
+
+    def test_missing_source_url_raises(self):
+      config = dict(_IDE_CONFIG)
+      config.pop("source_url")
+      with patch("scripts.fetchers.visual_studio.get_text"):
+        with pytest.raises(ValueError, match="missing required config value 'source_url'"):
+          fetch(config)

--- a/tests/test_visual_studio_fetcher.py
+++ b/tests/test_visual_studio_fetcher.py
@@ -77,8 +77,8 @@ class TestFetch:
         assert mock_get_text.call_args.args[0] == "https://example.test/visual-studio-2026"
 
     def test_missing_source_url_raises(self):
-      config = dict(_IDE_CONFIG)
-      config.pop("source_url")
-      with patch("scripts.fetchers.visual_studio.get_text"):
-        with pytest.raises(ValueError, match="missing required config value 'source_url'"):
-          fetch(config)
+        config = dict(_IDE_CONFIG)
+        config.pop("source_url")
+        with patch("scripts.fetchers.visual_studio.get_text"):
+            with pytest.raises(ValueError, match="missing required config value 'source_url'"):
+                fetch(config)

--- a/tests/test_vs_code_fetcher.py
+++ b/tests/test_vs_code_fetcher.py
@@ -17,6 +17,7 @@ _IDE_CONFIG = {
     "fetcher": "vs_code",
     "start_version": "1.75.0",
     "source_url": "https://code.visualstudio.com/feed.xml",
+    "release_url_template": "https://code.visualstudio.com/updates/v1_{n}",
 }
 
 # Minimal Atom feed XML with two release entries and one blog entry.
@@ -294,6 +295,27 @@ class TestFetch:
             results = fetch(custom_config)
 
         assert len(results) == 2
+
+    def test_uses_custom_release_url_template(self):
+        custom_config = {
+            **_IDE_CONFIG,
+            "release_url_template": "https://custom.example.com/updates/v1_{n}",
+        }
+        pages = {
+            "https://code.visualstudio.com/feed.xml": _FAKE_FEED_XML,
+            "https://custom.example.com/updates/v1_75": _FAKE_PAGE_HTML_75,
+            "https://custom.example.com/updates/v1_76": _FAKE_PAGE_HTML_76,
+        }
+        with patch("scripts.fetchers.vs_code.get_text", side_effect=self._make_get_text_side_effect(pages)):
+            results = fetch(custom_config)
+
+        assert len(results) == 2
+
+    def test_missing_release_url_template_raises(self):
+        config = dict(_IDE_CONFIG)
+        config.pop("release_url_template")
+        with pytest.raises(ValueError, match="missing required config value 'release_url_template'"):
+            fetch(config)
 
     def test_start_version_respected(self):
         """Only versions >= start_version are fetched."""

--- a/tests/test_xcode_fetcher.py
+++ b/tests/test_xcode_fetcher.py
@@ -5,10 +5,10 @@ import pathlib
 from unittest.mock import patch
 
 import jsonschema
+import pytest
 from bs4 import BeautifulSoup
 
 from scripts.fetchers.xcode import (
-    _FEATURE_MATRIX_URL,
     _extract_plugin_versions,
     _find_next_table,
     _find_section_heading,
@@ -22,6 +22,7 @@ _IDE_CONFIG = {
     "name": "GitHub Copilot for Xcode",
     "data_dir": "data/xcode",
     "fetcher": "xcode",
+    "source_url": "https://docs.github.com/en/copilot/reference/copilot-feature-matrix?tool=xcode",
 }
 
 # Minimal HTML that mirrors the real docs page structure.
@@ -259,10 +260,12 @@ class TestFetch:
             fetch(config)
         mock_get.assert_called_once_with("https://custom.example/matrix", use_auth=False)
 
-    def test_falls_back_to_default_url(self):
-        with patch("scripts.fetchers.xcode.get_text", return_value=_FAKE_HTML) as mock_get:
-            fetch(_IDE_CONFIG)
-        mock_get.assert_called_once_with(_FEATURE_MATRIX_URL, use_auth=False)
+    def test_missing_source_url_raises(self):
+        config = dict(_IDE_CONFIG)
+        config.pop("source_url")
+        with patch("scripts.fetchers.xcode.get_text"):
+            with pytest.raises(ValueError, match="missing required config value 'source_url'"):
+                fetch(config)
 
     def test_returns_list_of_dicts(self):
         with patch("scripts.fetchers.xcode.get_text", return_value=_FAKE_HTML):


### PR DESCRIPTION
This pull request introduces support for fetching and processing Visual Studio 2026 release notes, enforces stricter configuration validation across all fetchers, and improves configuration management for IDE fetchers. It adds a new workflow for automated release-note updates, updates documentation and configuration files, and refactors fetcher modules to require explicit configuration values.

**Visual Studio 2026 Support**
- Added a new fetcher module (`scripts/fetchers/visual_studio.py`) that parses Visual Studio 2026 release notes from HTML, extracting per-version sections with dates and content.
- Updated `config/ides.yml` to add a new entry for `visual-studio-2026`, specifying its data directory, fetcher, and source URL.
- Introduced a scheduled GitHub Actions workflow (`.github/workflows/fetch-visual-studio-2026.yml`) to fetch, commit, and auto-merge new Visual Studio 2026 release notes daily.
- Updated the `README.md` to document Visual Studio 2026 as a supported IDE.

**Configuration Management and Validation**
- Added a `require_config_value` utility in `scripts/common/config.py` to enforce that required config values are present and non-empty, raising errors otherwise.
- Refactored all fetcher modules (`jetbrains.py`, `eclipse.py`, `vs_code.py`, `copilot_vim.py`, `xcode.py`) to use `require_config_value` for critical configuration fields like `source_url` and other per-IDE settings, removing hardcoded defaults. [[1]](diffhunk://#diff-79850986a06637b660dabf41ed9226d73399959b7026c6dcb73ab002ba990974R17-L25) [[2]](diffhunk://#diff-79850986a06637b660dabf41ed9226d73399959b7026c6dcb73ab002ba990974L76-R77) [[3]](diffhunk://#diff-79850986a06637b660dabf41ed9226d73399959b7026c6dcb73ab002ba990974L127-R128) [[4]](diffhunk://#diff-0bb3219a3636e5cbf74037c71c409de497cacb997a2bf767bf5128495308f733R8-L12) [[5]](diffhunk://#diff-0bb3219a3636e5cbf74037c71c409de497cacb997a2bf767bf5128495308f733L28-R28) [[6]](diffhunk://#diff-5234fa3bac6bf20018953e2e4d99ac4e7b9a4a97551e367c7aff4e611eb18cbcR22-L26) [[7]](diffhunk://#diff-5234fa3bac6bf20018953e2e4d99ac4e7b9a4a97551e367c7aff4e611eb18cbcL117-R118) [[8]](diffhunk://#diff-5234fa3bac6bf20018953e2e4d99ac4e7b9a4a97551e367c7aff4e611eb18cbcL127-R127) [[9]](diffhunk://#diff-55d9c167ac3b46cf898b0d27245e8ffad50a9ffc8f7c0623ff884632bbb1b2e7R6-L12) [[10]](diffhunk://#diff-55d9c167ac3b46cf898b0d27245e8ffad50a9ffc8f7c0623ff884632bbb1b2e7L26-R31) [[11]](diffhunk://#diff-55d9c167ac3b46cf898b0d27245e8ffad50a9ffc8f7c0623ff884632bbb1b2e7L71-R76) [[12]](diffhunk://#diff-415048c9985d21d3a85355a0aa68c25320cd121324c7f1d072d29aeb45981826R6-L12) [[13]](diffhunk://#diff-415048c9985d21d3a85355a0aa68c25320cd121324c7f1d072d29aeb45981826L24-R29) [[14]](diffhunk://#diff-415048c9985d21d3a85355a0aa68c25320cd121324c7f1d072d29aeb45981826L69-R74)

**Configuration and Documentation Improvements**
- Centralized all fetcher endpoints and per-IDE configuration in `config/ides.yml`, including new fields like `plugin_url` and `release_url_template`. [[1]](diffhunk://#diff-34c6cb5c3ad9c34e35f56932aa7c35ea11ee90c859e9dca09dcf6fd08b95139eR21) [[2]](diffhunk://#diff-34c6cb5c3ad9c34e35f56932aa7c35ea11ee90c859e9dca09dcf6fd08b95139eR42-L44)
- Updated the `README.md` to clarify that fetcher endpoints are now centrally configured, and added documentation for the new supported IDEs. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R16-R17) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R26-R27)

**HTML Utilities**
- Added `scripts/common/html_split.py`, a helper module for splitting large HTML release-notes pages into per-version sections, used by the new Visual Studio fetcher.

**Testing**
- Minor test code cleanup to remove now-unused constants.