### PR TITLE
Introduce ruff linter

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -3,7 +3,8 @@
 - Documentation updated (do we need to update the README or other documentation?)
 - Ensure all GitHub Actions workflows use the latest versions of the actions they depend on. Look up the absolute latest released version across all major versions. Apply SHA pinning using the commit SHA with the version tag as a comment (e.g. `uses: actions/checkout@<sha> # vX.Y.Z`).
 - New tests added (if code was changed/added)
-- All tests pass
+- All tests pass (`pytest`)
+- Lint is clean (`ruff check scripts tests`)
 
 # Important notes
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,5 +30,8 @@ jobs:
       - name: Check Python syntax
         run: python -m compileall scripts tests
 
+      - name: Run linting
+        run: ruff check scripts tests
+
       - name: Run test suite
         run: pytest

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ ENV/
 
 # pytest
 .pytest_cache/
+.ruff_cache/
 
 # Data (exclude test/dummy data only; real IDE data is tracked)
 data/dummy/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,8 +17,11 @@ GITHUB_TOKEN=<your-token> python -m scripts.run --ide eclipse
 
 ```bash
 pip install -r requirements.txt
+ruff check scripts tests
 pytest
 ```
+
+Both `ruff` and `pytest` must pass before committing. Run them together as the local verification step.
 
 ## Repository layout
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[tool.ruff]
+target-version = "py312"
+line-length = 120
+
+[tool.ruff.lint]
+# Expanded phase-2 baseline: correctness, modernization, and simplification.
+select = ["E4", "E7", "E9", "F", "I", "UP", "B", "SIM", "RUF"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["scripts"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ lxml>=5.2.0
 markdownify>=0.13.0
 feedparser>=6.0.0
 pytest>=8.0.0
+ruff>=0.11.0

--- a/scripts/common/github_releases.py
+++ b/scripts/common/github_releases.py
@@ -1,6 +1,6 @@
 """Shared helpers for GitHub Releases based fetchers."""
 import re
-from typing import Callable
+from collections.abc import Callable
 
 from scripts.common.changelog import split_changelog_by_version
 from scripts.common.extract import extract_copilot_mentions

--- a/scripts/common/io.py
+++ b/scripts/common/io.py
@@ -1,7 +1,7 @@
 """Idempotent JSON writer for release records."""
 import json
 import pathlib
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 
 def write_release(data_dir: pathlib.Path, release: dict) -> bool:
@@ -14,7 +14,7 @@ def write_release(data_dir: pathlib.Path, release: dict) -> bool:
     path = data_dir / f"{release['version']}.json"
     if path.exists():
         return False
-    release.setdefault("fetched_at", datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"))
+    release.setdefault("fetched_at", datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"))
     release.setdefault("schema_version", 1)
     path.write_text(json.dumps(release, indent=2, ensure_ascii=False), encoding="utf-8")
     return True

--- a/scripts/fetchers/copilot_vim.py
+++ b/scripts/fetchers/copilot_vim.py
@@ -141,9 +141,8 @@ def _find_next_table(heading: Tag) -> Tag | None:
     for element in heading.next_siblings:
         if not isinstance(element, Tag):
             continue
-        if _HEADING_RE.match(element.name or ""):
-            if int(element.name[1]) <= heading_level:
-                break
+        if _HEADING_RE.match(element.name or "") and int(element.name[1]) <= heading_level:
+            break
         if element.name == "table":
             return element
         nested = element.find("table")

--- a/scripts/fetchers/jetbrains.py
+++ b/scripts/fetchers/jetbrains.py
@@ -12,7 +12,7 @@ Each semver maps to multiple build-line entries (e.g. -241, -242, -243).
 We group them into one JSON file per semver with a `builds[]` array.
 """
 import re
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 from scripts.common.config import require_config_value
 from scripts.common.extract import extract_copilot_mentions, html_to_markdown
@@ -95,7 +95,7 @@ def fetch(ide_config: dict) -> list[dict]:
         earliest_cdate = min(cdate_values)
         if earliest_cdate:
             release_date = datetime.fromtimestamp(
-                earliest_cdate / 1000, tz=timezone.utc
+                earliest_cdate / 1000, tz=UTC
             ).strftime("%Y-%m-%d")
         else:
             release_date = "1970-01-01"

--- a/scripts/fetchers/vs_code.py
+++ b/scripts/fetchers/vs_code.py
@@ -128,7 +128,7 @@ def fetch(ide_config: dict) -> list[dict]:
 
         try:
             html = get_text(page_url, use_auth=False)
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             print(f"  [warn] Failed to fetch {page_url}: {exc}")
             continue
 

--- a/scripts/fetchers/xcode.py
+++ b/scripts/fetchers/xcode.py
@@ -139,9 +139,8 @@ def _find_next_table(heading: Tag) -> Tag | None:
     for element in heading.next_siblings:
         if not isinstance(element, Tag):
             continue
-        if _HEADING_RE.match(element.name or ""):
-            if int(element.name[1]) <= heading_level:
-                break
+        if _HEADING_RE.match(element.name or "") and int(element.name[1]) <= heading_level:
+            break
         if element.name == "table":
             return element
         nested = element.find("table")

--- a/tests/test_copilot_vim_fetcher.py
+++ b/tests/test_copilot_vim_fetcher.py
@@ -248,9 +248,10 @@ class TestFetch:
     def test_missing_source_url_raises(self):
         config = dict(_IDE_CONFIG)
         config.pop("source_url")
-        with patch("scripts.fetchers.copilot_vim.get_text"):
-            with pytest.raises(ValueError, match="missing required config value 'source_url'"):
-                fetch(config)
+        with patch("scripts.fetchers.copilot_vim.get_text"), pytest.raises(
+            ValueError, match="missing required config value 'source_url'"
+        ):
+            fetch(config)
 
     def test_returns_list_of_dicts(self):
         with patch("scripts.fetchers.copilot_vim.get_text", return_value=_FAKE_HTML):

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1,5 +1,4 @@
 """Tests for scripts/common/extract.py"""
-import pytest
 
 from scripts.common.extract import extract_copilot_mentions, html_to_markdown
 

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -2,11 +2,10 @@
 import os
 from unittest.mock import MagicMock, patch
 
-import pytest
 import requests
 
 import scripts.common.http as http_module
-from scripts.common.http import get_session, get_text, _build_session
+from scripts.common.http import _build_session, get_session, get_text
 
 
 class TestBuildSession:

--- a/tests/test_jetbrains_fetcher.py
+++ b/tests/test_jetbrains_fetcher.py
@@ -1,4 +1,5 @@
 """Tests for scripts/fetchers/jetbrains.py"""
+from typing import ClassVar
 from unittest.mock import patch
 
 import pytest
@@ -267,9 +268,10 @@ class TestFetch:
     def test_missing_plugin_url_raises(self):
         config = dict(_IDE_CONFIG)
         config.pop("plugin_url")
-        with pytest.raises(ValueError, match="missing required config value 'plugin_url'"):
-            with patch("scripts.fetchers.jetbrains.get_json", return_value=[]):
-                fetch(config)
+        with patch("scripts.fetchers.jetbrains.get_json", return_value=[]), pytest.raises(
+            ValueError, match="missing required config value 'plugin_url'"
+        ):
+            fetch(config)
 
     def test_builds_contain_since_and_until(self):
         releases = self._run_fetch([_FAKE_UPDATES_PAGE1, []])
@@ -321,7 +323,7 @@ class TestFetch:
 class TestFetchLegacyVersions:
     """Tests for legacy 4-part no-build-suffix versions (e.g. 1.5.29.7524)."""
 
-    _FAKE_LEGACY = [
+    _FAKE_LEGACY: ClassVar[list[dict]] = [
         {
             "id": 5001,
             "version": "1.5.29.7524",
@@ -385,7 +387,7 @@ class TestFetchLegacyVersions:
         releases = self._run_fetch([self._FAKE_LEGACY, []])
         # Add required fields that write_release would normally inject
         for r in releases:
-            r["fetched_at"] = _dt.datetime.now(_dt.timezone.utc).isoformat()
+            r["fetched_at"] = _dt.datetime.now(_dt.UTC).isoformat()
             r["schema_version"] = 1
         for r in releases:
             jsonschema.validate(r, schema)  # raises if invalid

--- a/tests/test_visual_studio_fetcher.py
+++ b/tests/test_visual_studio_fetcher.py
@@ -79,6 +79,7 @@ class TestFetch:
     def test_missing_source_url_raises(self):
         config = dict(_IDE_CONFIG)
         config.pop("source_url")
-        with patch("scripts.fetchers.visual_studio.get_text"):
-            with pytest.raises(ValueError, match="missing required config value 'source_url'"):
-                fetch(config)
+        with patch("scripts.fetchers.visual_studio.get_text"), pytest.raises(
+            ValueError, match="missing required config value 'source_url'"
+        ):
+            fetch(config)

--- a/tests/test_vs_code_fetcher.py
+++ b/tests/test_vs_code_fetcher.py
@@ -1,5 +1,5 @@
 """Tests for scripts/fetchers/vs_code.py"""
-from unittest.mock import call, patch
+from unittest.mock import patch
 
 import pytest
 

--- a/tests/test_xcode_fetcher.py
+++ b/tests/test_xcode_fetcher.py
@@ -247,7 +247,7 @@ class TestSchemaValidation:
         schema = json.loads(pathlib.Path("scripts/common/schema.json").read_text())
         results = _parse_feature_matrix(_IDE_CONFIG, _FAKE_HTML)
         for r in results:
-            r["fetched_at"] = datetime.datetime.now(datetime.timezone.utc).isoformat()
+            r["fetched_at"] = datetime.datetime.now(datetime.UTC).isoformat()
             r["schema_version"] = 1
         for r in results:
             jsonschema.validate(r, schema)  # raises if invalid
@@ -263,9 +263,10 @@ class TestFetch:
     def test_missing_source_url_raises(self):
         config = dict(_IDE_CONFIG)
         config.pop("source_url")
-        with patch("scripts.fetchers.xcode.get_text"):
-            with pytest.raises(ValueError, match="missing required config value 'source_url'"):
-                fetch(config)
+        with patch("scripts.fetchers.xcode.get_text"), pytest.raises(
+            ValueError, match="missing required config value 'source_url'"
+        ):
+            fetch(config)
 
     def test_returns_list_of_dicts(self):
         with patch("scripts.fetchers.xcode.get_text", return_value=_FAKE_HTML):


### PR DESCRIPTION
This pull request introduces linting with Ruff, updates project documentation and CI to require lint and test checks, and makes several code quality improvements. It also includes minor refactoring for clarity and modernization, especially around datetime usage and test code structure.

**Tooling and CI improvements:**

* Added Ruff linting configuration to `pyproject.toml` and integrated Ruff checks into the CI workflow and documentation, ensuring lint passes locally and in CI before commits (`pyproject.toml`, `.github/workflows/ci.yml`, `.github/copilot-instructions.md`, `AGENTS.md`). [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R1-R10) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR33-R35) [[3]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L6-R7) [[4]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R20-R25)
* Updated documentation to clarify that both lint (`ruff check scripts tests`) and tests (`pytest`) must pass before committing. [[1]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R20-R25) [[2]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L6-R7)

**Code modernization and simplification:**

* Replaced deprecated or less explicit imports with modern Python equivalents, e.g., using `UTC` from `datetime` instead of `timezone.utc`, and importing `Callable` from `collections.abc`. [[1]](diffhunk://#diff-83755652c3eb42498f4d8ab86825f9e6bcbfab753bcd3e8086efa9f11efc094bL4-R4) [[2]](diffhunk://#diff-79850986a06637b660dabf41ed9226d73399959b7026c6dcb73ab002ba990974L15-R15) [[3]](diffhunk://#diff-79850986a06637b660dabf41ed9226d73399959b7026c6dcb73ab002ba990974L98-R98) [[4]](diffhunk://#diff-5c7f48b223ee29028dc299aaadea22abdbbf522cde5f6fa52f14ca88722550d2L3-R3)
* Simplified logic in functions like `_find_next_table` by combining conditions for better readability. [[1]](diffhunk://#diff-55d9c167ac3b46cf898b0d27245e8ffad50a9ffc8f7c0623ff884632bbb1b2e7L144-R144) [[2]](diffhunk://#diff-415048c9985d21d3a85355a0aa68c25320cd121324c7f1d072d29aeb45981826L142-R142)

**Test improvements and cleanup:**

* Refactored test cases to use more concise `with` statements and improved patching patterns, and added typing annotations for clarity. [[1]](diffhunk://#diff-f0fc26d3c172672a1ec9cbd5cfd6f82236eae7789bcb1ae758c9c5f924694ba1R2) [[2]](diffhunk://#diff-f0fc26d3c172672a1ec9cbd5cfd6f82236eae7789bcb1ae758c9c5f924694ba1L270-R273) [[3]](diffhunk://#diff-f0fc26d3c172672a1ec9cbd5cfd6f82236eae7789bcb1ae758c9c5f924694ba1L324-R326) [[4]](diffhunk://#diff-f0fc26d3c172672a1ec9cbd5cfd6f82236eae7789bcb1ae758c9c5f924694ba1L388-R390) [[5]](diffhunk://#diff-4ee7f6c0519ea60bc4dfd36e7027afdca5b8f5b814c990aa4fa03a0095ff6879L82-R84) [[6]](diffhunk://#diff-4519b35e4a9241f7108d8cf8babcfc8ba1760f54111ede468b953627beded072L251-R253) [[7]](diffhunk://#diff-b95c0f4017f7f4ea21406bc91656ecee05e0b655c8c99a3b39e5ea000dea1482L250-R250) [[8]](diffhunk://#diff-b95c0f4017f7f4ea21406bc91656ecee05e0b655c8c99a3b39e5ea000dea1482L266-R268) [[9]](diffhunk://#diff-c9be93ded566378ce85882abe8aac75673abc1e9cc88f3d8926c617cc16b25ffL2-R2) [[10]](diffhunk://#diff-c004679546311e65d99f8cf55b34e6eadd4e7f59061e36d7875fec4a3bc0bc15L5-R8) [[11]](diffhunk://#diff-24ff2537b4f0f0e2917e279686bf69fb986c20223430905764ef2f6a0e53a975L2)

**Minor codebase maintenance:**

* Updated import order and removed unused imports to comply with linting rules and improve readability. [[1]](diffhunk://#diff-c9be93ded566378ce85882abe8aac75673abc1e9cc88f3d8926c617cc16b25ffL2-R2) [[2]](diffhunk://#diff-c004679546311e65d99f8cf55b34e6eadd4e7f59061e36d7875fec4a3bc0bc15L5-R8) [[3]](diffhunk://#diff-24ff2537b4f0f0e2917e279686bf69fb986c20223430905764ef2f6a0e53a975L2)
* Removed unnecessary `noqa` comments where they are no longer needed.

These changes collectively improve code quality, enforce modern Python standards, and ensure a more robust CI process.