### PR TITLE
Find feature skill

### DIFF
--- a/.github/skills/find-feature/SKILL.md
+++ b/.github/skills/find-feature/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: find-feature
+description: Use the release notes in the data folder of this repository to determine from which version on for every IDE a specific feature is available.
+argument-hint: "Name or description of the feature"
+---
+
+GitHub Copilot is an AI coding assistant, supported in the following IDEs:
+- Visual Studio Code
+- Visual Studio 2022 and 2026
+- JetBrains IDEs (e.g., IntelliJ IDEA, PyCharm, WebStorm)
+- Neovim
+- Eclipse
+- Xcode
+- SQL Server Management Studio (SSMS)
+
+Every IDE has a different support for GitHub Copilot features, and the availability of features may vary across versions. To determine from which version on a specific feature is available for each IDE, you can refer to the release notes in the data folder of this repository. The release notes contain detailed information about the features introduced in each version of GitHub Copilot for different IDEs. By reviewing these notes, you can identify when a particular feature was added and which IDEs support it.
+
+## Output format
+
+Generate a markdown table with the following columns:
+| IDE | Version Introduced | Feature Description |
+| --- | --- | --- |
+Where:
+- **IDE**: The name of the Integrated Development Environment (IDE) that supports the feature.
+- **Version Introduced**: The version of GitHub Copilot in which the feature was first introduced for that IDE.
+- **Feature Description**: A brief description of the feature, as provided in the release notes.
+
+## Important notes
+
+- Visual Studio 2026 contains all features Visual Studio 2022 has

--- a/.github/skills/find-feature/SKILL.md
+++ b/.github/skills/find-feature/SKILL.md
@@ -17,12 +17,15 @@ Every IDE has a different support for GitHub Copilot features, and the availabil
 
 ## Output format
 
-Generate a markdown table with the following columns:
-| IDE | Version Introduced | Feature Description |
-| --- | --- | --- |
+Generate a markdown table with the following columns, where every IDE where the feature is present, is represented as a row:
+
+| IDE | Version Introduced (Preview/beta/insiders) | Version Introduced (GA/stable) | Feature Description |
+| --- | --- | --- | --- |
+
 Where:
 - **IDE**: The name of the Integrated Development Environment (IDE) that supports the feature.
-- **Version Introduced**: The version of GitHub Copilot in which the feature was first introduced for that IDE.
+- **Version Introduced (Preview/beta/insiders)**: The version of the IDE in which the feature was first introduced for that IDE where the feature was in preview, or in beta or in the insiders version of that IDE. If none can be found, leave empty.
+- **Version Introduced (GA/stable)**: The version of the IDE in which the feature became part of the GA or stable version of the IDE. It can also the feature was never part of the Preview/beta/insiders, then it should be mentioned in this column only.
 - **Feature Description**: A brief description of the feature, as provided in the release notes.
 
 ## Important notes

--- a/.github/skills/find-feature/SKILL.md
+++ b/.github/skills/find-feature/SKILL.md
@@ -25,7 +25,7 @@ Generate a markdown table with the following columns, where every IDE where the 
 Where:
 - **IDE**: The name of the Integrated Development Environment (IDE) that supports the feature.
 - **Version Introduced (Preview/beta/insiders)**: The version of the IDE in which the feature was first introduced for that IDE where the feature was in preview, or in beta or in the insiders version of that IDE. If none can be found, leave empty.
-- **Version Introduced (GA/stable)**: The version of the IDE in which the feature became part of the GA or stable version of the IDE. It can also the feature was never part of the Preview/beta/insiders, then it should be mentioned in this column only.
+- **Version Introduced (GA/stable)**: The version of the IDE in which the feature became part of the GA or stable version of the IDE. If the feature was never introduced in a preview, beta, or insiders release, mention it only in this column and leave the preview/beta/insiders column empty.
 - **Feature Description**: A brief description of the feature, as provided in the release notes.
 
 ## Important notes

--- a/.github/skills/find-feature/SKILL.md
+++ b/.github/skills/find-feature/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: find-feature
-description: Use the release notes in the data folder of this repository to determine from which version on for every IDE a specific feature is available.
+description: Use the release notes in the data folder of this repository to determine from which version onwards for every IDE a specific feature is available.
 argument-hint: "Name or description of the feature"
 ---
 
@@ -13,7 +13,7 @@ GitHub Copilot is an AI coding assistant, supported in the following IDEs:
 - Xcode
 - SQL Server Management Studio (SSMS)
 
-Every IDE has a different support for GitHub Copilot features, and the availability of features may vary across versions. To determine from which version on a specific feature is available for each IDE, you can refer to the release notes in the data folder of this repository. The release notes contain detailed information about the features introduced in each version of GitHub Copilot for different IDEs. By reviewing these notes, you can identify when a particular feature was added and which IDEs support it.
+Every IDE has a different support for GitHub Copilot features, and the availability of features may vary across versions. To determine from which version onwards a specific feature is available for each IDE, you can refer to the release notes in the data folder of this repository. The release notes contain detailed information about the features introduced in each version of GitHub Copilot for different IDEs. By reviewing these notes, you can identify when a particular feature was added and which IDEs support it.
 
 ## Output format
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 This repository collects release notes for GitHub Copilot features across different IDEs. Scheduled GitHub Actions workflows collect the release notes from the official IDEs and IDE extensions/plugins and store these in json files.
 
+## Usage
+
+The repository contains a **Skill** that can be used along with GitHub Copilot or another AI coding assistant to query the collected release notes data. For example, you can ask:
+
+`/find-feature Next Edit Suggestions (NES)`
+
+It would then return a summary of the release notes for that feature across all IDEs, including which IDEs versions support it. The repository data is updated daily by scheduled GitHub Actions workflows, so you can be confident that the information is up to date. Do recent pulls of this repository to get the latest data before asking the Skill.
+
 ## Repository layout
 
 ```

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The repository contains a **Skill** that can be used along with GitHub Copilot o
 
 `/find-feature Next Edit Suggestions (NES)`
 
-It would then return a summary of the release notes for that feature across all IDEs, including which IDEs versions support it. The repository data is updated daily by scheduled GitHub Actions workflows, so you can be confident that the information is up to date. Do recent pulls of this repository to get the latest data before asking the Skill.
+It would then return a summary of the release notes for that feature across all IDEs, including which IDE versions support it. The repository data is updated daily by scheduled GitHub Actions workflows, so you can be confident that the information is up to date. Pull the latest changes in this repository before asking the Skill so you have the latest data.
 
 ## Repository layout
 


### PR DESCRIPTION
This pull request introduces a new Skill for querying feature availability across IDEs and updates the repository documentation to describe its usage. The main changes are the addition of a markdown file detailing the Skill's functionality and output format, and an update to the `README.md` to explain how to use the Skill.

**Skill addition and documentation:**

* Added `.github/skills/find-feature/SKILL.md` to define the `find-feature` Skill, including instructions on how to determine from which version a specific feature is available in each IDE, and specifying the required output format as a markdown table.
* Updated `README.md` to document the new Skill, providing usage instructions and an example query, as well as clarifying that the repository data is updated daily.