### PR TITLE
Implement changelog.md support for Xcode Copilot release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ The fetchers that call the GitHub REST API (Eclipse, GitHub Copilot CLI) only re
 
 > **Note:** The Vim/Neovim fetcher does not use the GitHub REST API. It scrapes the [GitHub Copilot feature matrix](https://docs.github.com/en/copilot/reference/copilot-feature-matrix?tool=vimneovim) docs page, which is publicly accessible without authentication.
 
+> **Note:** The Xcode fetcher combines two sources: the [GitHub Copilot feature matrix](https://docs.github.com/en/copilot/reference/copilot-feature-matrix?tool=xcode) (which features each version supports) and the [CopilotForXcode `CHANGELOG.md`](https://github.com/github/CopilotForXcode/blob/main/CHANGELOG.md) (what changed in each release, plus the real release date). Changelog notes are merged into the matching feature-matrix records under a **Supported features** heading, and changelog-only versions are added as extra records. Both sources are fetched without the GitHub token.
+
 | Token type | Required scopes |
 |-----------|----------------|
 | Personal access token (classic) | *(none — leave all scopes unchecked)* |

--- a/README.md
+++ b/README.md
@@ -73,10 +73,6 @@ Re-running the same command is safe: existing files are never overwritten (idemp
 
 The fetchers that call the GitHub REST API (Eclipse, GitHub Copilot CLI) only read **public** repositories, so no specific OAuth scopes are required. Any of the following work:
 
-> **Note:** The Vim/Neovim fetcher does not use the GitHub REST API. It scrapes the [GitHub Copilot feature matrix](https://docs.github.com/en/copilot/reference/copilot-feature-matrix?tool=vimneovim) docs page, which is publicly accessible without authentication.
-
-> **Note:** The Xcode fetcher combines two sources: the [GitHub Copilot feature matrix](https://docs.github.com/en/copilot/reference/copilot-feature-matrix?tool=xcode) (which features each version supports) and the [CopilotForXcode `CHANGELOG.md`](https://github.com/github/CopilotForXcode/blob/main/CHANGELOG.md) (what changed in each release, plus the real release date). Changelog notes are merged into the matching feature-matrix records, with the feature list kept under a **Supported features** heading, and changelog-only versions are added as extra records. Both sources are fetched without the GitHub token.
-
 | Token type | Required scopes |
 |-----------|----------------|
 | Personal access token (classic) | *(none — leave all scopes unchecked)* |

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The fetchers that call the GitHub REST API (Eclipse, GitHub Copilot CLI) only re
 
 > **Note:** The Vim/Neovim fetcher does not use the GitHub REST API. It scrapes the [GitHub Copilot feature matrix](https://docs.github.com/en/copilot/reference/copilot-feature-matrix?tool=vimneovim) docs page, which is publicly accessible without authentication.
 
-> **Note:** The Xcode fetcher combines two sources: the [GitHub Copilot feature matrix](https://docs.github.com/en/copilot/reference/copilot-feature-matrix?tool=xcode) (which features each version supports) and the [CopilotForXcode `CHANGELOG.md`](https://github.com/github/CopilotForXcode/blob/main/CHANGELOG.md) (what changed in each release, plus the real release date). Changelog notes are merged into the matching feature-matrix records under a **Supported features** heading, and changelog-only versions are added as extra records. Both sources are fetched without the GitHub token.
+> **Note:** The Xcode fetcher combines two sources: the [GitHub Copilot feature matrix](https://docs.github.com/en/copilot/reference/copilot-feature-matrix?tool=xcode) (which features each version supports) and the [CopilotForXcode `CHANGELOG.md`](https://github.com/github/CopilotForXcode/blob/main/CHANGELOG.md) (what changed in each release, plus the real release date). Changelog notes are merged into the matching feature-matrix records, with the feature list kept under a **Supported features** heading, and changelog-only versions are added as extra records. Both sources are fetched without the GitHub token.
 
 | Token type | Required scopes |
 |-----------|----------------|

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Re-running the same command is safe: existing files are never overwritten (idemp
 
 ### GitHub token scopes
 
-The fetchers that call the GitHub REST API (Eclipse, GitHub Copilot CLI) only read **public** repositories, so no specific OAuth scopes are required. Any of the following work:
+The fetchers that call the GitHub REST API (Eclipse, GitHub Copilot CLI) only read **public** repositories, so no specific OAuth scopes are required. Xcode (feature matrix + public `CHANGELOG.md`) and Vim/Neovim scrape public docs and do not require authentication.
 
 | Token type | Required scopes |
 |-----------|----------------|

--- a/config/ides.yml
+++ b/config/ides.yml
@@ -33,6 +33,7 @@ ides:
     fetcher: xcode
     start_version: all
     source_url: https://docs.github.com/en/copilot/reference/copilot-feature-matrix?tool=xcode
+    changelog_url: https://raw.githubusercontent.com/github/CopilotForXcode/main/CHANGELOG.md
 
   - id: vim-neovim
     name: GitHub Copilot for Vim/Neovim

--- a/scripts/fetchers/xcode.py
+++ b/scripts/fetchers/xcode.py
@@ -41,7 +41,7 @@ _SECTIONS: list[tuple[str, str, str]] = [
 ]
 
 # Fallback release date for changelog-only records whose heading has no parseable date.
-_DEFAULT_ERA_DATE = "2026-01-01"
+_DEFAULT_ERA_DATE = next(date for _, key, date in _SECTIONS if key == "xcode-latest")
 
 # Matches changelog headings like "## 0.50.0 - May 20, 2026" (hyphen or en-dash separator).
 _CHANGELOG_DATE_RE = re.compile(

--- a/scripts/fetchers/xcode.py
+++ b/scripts/fetchers/xcode.py
@@ -104,11 +104,12 @@ def _parse_feature_matrix(
         results.extend(records)
 
     if changelog_markdown:
+        effective_changelog_url = changelog_url or ide_config.get("changelog_url") or source_url
         results = _merge_changelog(
             results,
             ide_config,
             changelog_markdown,
-            changelog_url=changelog_url or source_url,
+            changelog_url=effective_changelog_url,
         )
 
     return results

--- a/scripts/fetchers/xcode.py
+++ b/scripts/fetchers/xcode.py
@@ -43,9 +43,10 @@ _SECTIONS: list[tuple[str, str, str]] = [
 # Fallback release date for changelog-only records whose heading has no parseable date.
 _DEFAULT_ERA_DATE = next(date for _, key, date in _SECTIONS if key == "xcode-latest")
 
-# Matches changelog headings like "## 0.50.0 - May 20, 2026" (hyphen or en-dash separator).
+# Matches changelog headings like "## 0.50.0 - May 20, 2026" or "## [0.50.0] - May 20, 2026"
+# (optional brackets around the version, hyphen or en-dash separator).
 _CHANGELOG_DATE_RE = re.compile(
-    r"^##\s+v?(?P<version>\d+(?:\.\d+){1,3})\s*[-\u2013]\s*"
+    r"^##\s+\[?v?(?P<version>\d+(?:\.\d+){1,3})\]?\s*[-\u2013]\s*"
     r"(?P<date>[A-Z][a-z]+\s+\d{1,2},\s+\d{4})",
     re.MULTILINE,
 )

--- a/scripts/fetchers/xcode.py
+++ b/scripts/fetchers/xcode.py
@@ -1,7 +1,22 @@
-"""Xcode fetcher — feature matrix from GitHub Copilot docs."""
+"""Xcode fetcher — feature matrix from GitHub Copilot docs.
+
+The record set combines two complementary sources:
+
+* the GitHub Copilot **feature matrix** docs page, which lists which features
+  each plugin version supports, and
+* the CopilotForXcode **CHANGELOG.md**, which describes what actually changed in
+  each release (and carries the real release date).
+
+The changelog notes are merged into the matching feature-matrix records and any
+changelog-only versions are added as extra records, so no feature data is lost.
+"""
+
+import re
+from datetime import datetime
 
 from bs4 import BeautifulSoup, Tag
 
+from scripts.common.changelog import split_changelog_by_version
 from scripts.common.config import require_config_value
 from scripts.common.extract import extract_copilot_mentions
 from scripts.common.feature_matrix import (
@@ -25,14 +40,43 @@ _SECTIONS: list[tuple[str, str, str]] = [
     ("Xcode 2024 releases", "xcode-2024", "2024-01-01"),
 ]
 
+# Fallback release date for changelog-only records whose heading has no parseable date.
+_DEFAULT_ERA_DATE = "2026-01-01"
+
+# Matches changelog headings like "## 0.50.0 - May 20, 2026" (hyphen or en-dash separator).
+_CHANGELOG_DATE_RE = re.compile(
+    r"^##\s+v?(?P<version>\d+(?:\.\d+){1,3})\s*[-\u2013]\s*"
+    r"(?P<date>[A-Z][a-z]+\s+\d{1,2},\s+\d{4})",
+    re.MULTILINE,
+)
+
+
 def fetch(ide_config: dict) -> list[dict]:
     source_url = require_config_value(ide_config, "source_url")
     html = get_text(source_url, use_auth=False)
-    return _parse_feature_matrix(ide_config, html, source_url=source_url)
+
+    changelog_markdown = None
+    changelog_url = ide_config.get("changelog_url")
+    if changelog_url:
+        # Never send the GitHub token when fetching data destined for ./data.
+        changelog_markdown = get_text(changelog_url, use_auth=False)
+
+    return _parse_feature_matrix(
+        ide_config,
+        html,
+        source_url=source_url,
+        changelog_markdown=changelog_markdown,
+        changelog_url=changelog_url,
+    )
 
 
 def _parse_feature_matrix(
-    ide_config: dict, html: str, *, source_url: str | None = None
+    ide_config: dict,
+    html: str,
+    *,
+    source_url: str | None = None,
+    changelog_markdown: str | None = None,
+    changelog_url: str | None = None,
 ) -> list[dict]:
     source_url = source_url or require_config_value(ide_config, "source_url")
     soup = BeautifulSoup(html, "lxml")
@@ -59,7 +103,102 @@ def _parse_feature_matrix(
         )
         results.extend(records)
 
+    if changelog_markdown:
+        results = _merge_changelog(
+            results,
+            ide_config,
+            changelog_markdown,
+            changelog_url=changelog_url or source_url,
+        )
+
     return results
+
+
+def _extract_changelog_dates(changelog_markdown: str) -> dict[str, str]:
+    """Return ``{version: YYYY-MM-DD}`` parsed from changelog headings."""
+    dates: dict[str, str] = {}
+    for match in _CHANGELOG_DATE_RE.finditer(changelog_markdown):
+        version = match.group("version").lstrip("vV")
+        if version in dates:
+            continue
+        try:
+            parsed = datetime.strptime(match.group("date"), "%B %d, %Y")
+        except ValueError:
+            continue
+        dates[version] = parsed.strftime("%Y-%m-%d")
+    return dates
+
+
+def _era_for_date(iso_date: str | None) -> tuple[str, str]:
+    """Return the ``(era_key, heading_text)`` for a changelog-only version."""
+    year: int | None = None
+    if iso_date:
+        try:
+            year = int(iso_date[:4])
+        except ValueError:
+            year = None
+    if year is None or year >= 2026:
+        return "xcode-latest", "Xcode latest releases"
+    if year == 2025:
+        return "xcode-2025", "Xcode 2025 releases"
+    return "xcode-2024", "Xcode 2024 releases"
+
+
+def _compose_body(changelog_body: str, feature_body: str) -> str:
+    """Combine changelog notes with the supported-feature list."""
+    parts: list[str] = []
+    if changelog_body.strip():
+        parts.append(changelog_body.strip())
+    if feature_body.strip():
+        parts.append(f"### Supported features\n{feature_body.strip()}")
+    return "\n\n".join(parts)
+
+
+def _merge_changelog(
+    records: list[dict],
+    ide_config: dict,
+    changelog_markdown: str,
+    *,
+    changelog_url: str,
+) -> list[dict]:
+    """Enrich matrix records with changelog notes and add changelog-only versions."""
+    sections = split_changelog_by_version(changelog_markdown)
+    dates = _extract_changelog_dates(changelog_markdown)
+    matrix_versions = {record["version"] for record in records}
+
+    for record in records:
+        version = record["version"]
+        changelog_body = sections.get(version, "").strip()
+        if changelog_body:
+            record["body_markdown"] = _compose_body(changelog_body, record["body_markdown"])
+            record["copilot_mentions"] = extract_copilot_mentions(record["body_markdown"])
+        if version in dates:
+            record["release_date"] = dates[version]
+
+    for version, changelog_body in sections.items():
+        if version in matrix_versions:
+            continue
+        release_date = dates.get(version)
+        era_key, heading_text = _era_for_date(release_date)
+        body_markdown = changelog_body.strip()
+        records.append(
+            {
+                "ide": ide_config["id"],
+                "version": version,
+                "xcode_era": era_key,
+                "release_date": release_date or _DEFAULT_ERA_DATE,
+                "title": f"GitHub Copilot for Xcode {version} \u2013 {heading_text}",
+                "url": changelog_url,
+                "source": "html",
+                "body_markdown": body_markdown,
+                "body_html": None,
+                "categories": [],
+                "copilot_mentions": extract_copilot_mentions(body_markdown),
+                "prerelease": False,
+            }
+        )
+
+    return records
 
 
 _NOT_SUPPORTED = "✗"

--- a/scripts/fetchers/xcode.py
+++ b/scripts/fetchers/xcode.py
@@ -132,18 +132,21 @@ def _extract_changelog_dates(changelog_markdown: str) -> dict[str, str]:
 
 
 def _era_for_date(iso_date: str | None) -> tuple[str, str]:
-    """Return the ``(era_key, heading_text)`` for a changelog-only version."""
-    year: int | None = None
-    if iso_date:
-        try:
-            year = int(iso_date[:4])
-        except ValueError:
-            year = None
-    if year is None or year >= 2026:
-        return "xcode-latest", "Xcode latest releases"
-    if year == 2025:
-        return "xcode-2025", "Xcode 2025 releases"
-    return "xcode-2024", "Xcode 2024 releases"
+    """Return the ``(era_key, heading_text)`` for a changelog-only version.
+
+    Derives the era from ``_SECTIONS`` start dates (ordered newest-first) so it
+    stays in sync when sections are added or changed.
+    """
+    if not iso_date or not re.match(r"^\d{4}-\d{2}-\d{2}$", iso_date):
+        heading_text, era_key, _ = _SECTIONS[0]
+        return era_key, heading_text
+
+    for heading_text, era_key, start_date in _SECTIONS:
+        if iso_date >= start_date:
+            return era_key, heading_text
+
+    heading_text, era_key, _ = _SECTIONS[-1]
+    return era_key, heading_text
 
 
 def _compose_body(changelog_body: str, feature_body: str) -> str:

--- a/tests/test_xcode_fetcher.py
+++ b/tests/test_xcode_fetcher.py
@@ -9,9 +9,12 @@ import pytest
 from bs4 import BeautifulSoup
 
 from scripts.fetchers.xcode import (
+    _era_for_date,
+    _extract_changelog_dates,
     _extract_plugin_versions,
     _find_next_table,
     _find_section_heading,
+    _merge_changelog,
     _parse_feature_matrix,
     _table_to_markdown,
     fetch,
@@ -24,6 +27,25 @@ _IDE_CONFIG = {
     "fetcher": "xcode",
     "source_url": "https://docs.github.com/en/copilot/reference/copilot-feature-matrix?tool=xcode",
 }
+
+_FAKE_CHANGELOG = """\
+# Changelog
+
+## 0.48.0 - April 23, 2026
+### Added
+- Context window usage details in chat.
+
+### Changed
+- Custom agents are now generally available.
+
+## 0.40.0 - July 24, 2025
+### Added
+- Support disabling Agent mode when disabled by policy.
+
+## 0.31.0 - February 11, 2025 (Public Preview)
+### Added
+- Added Copilot Chat support.
+"""
 
 # Minimal HTML that mirrors the real docs page structure.
 _FAKE_HTML = """\
@@ -280,4 +302,121 @@ class TestFetch:
         with patch("scripts.fetchers.xcode.get_text", return_value=_FAKE_HTML):
             results = fetch(config)
         assert all(r["url"] == "https://custom.example/matrix" for r in results)
+
+
+class TestExtractChangelogDates:
+    def test_parses_dates_per_version(self):
+        dates = _extract_changelog_dates(_FAKE_CHANGELOG)
+        assert dates["0.48.0"] == "2026-04-23"
+        assert dates["0.40.0"] == "2025-07-24"
+
+    def test_ignores_trailing_heading_text(self):
+        dates = _extract_changelog_dates(_FAKE_CHANGELOG)
+        # "## 0.31.0 - February 11, 2025 (Public Preview)"
+        assert dates["0.31.0"] == "2025-02-11"
+
+    def test_returns_empty_for_no_dates(self):
+        assert _extract_changelog_dates("## 1.0.0\nNo date here.") == {}
+
+
+class TestEraForDate:
+    def test_2026_is_latest(self):
+        assert _era_for_date("2026-04-23") == ("xcode-latest", "Xcode latest releases")
+
+    def test_2025(self):
+        assert _era_for_date("2025-07-24") == ("xcode-2025", "Xcode 2025 releases")
+
+    def test_2024_and_older(self):
+        assert _era_for_date("2024-01-05") == ("xcode-2024", "Xcode 2024 releases")
+
+    def test_missing_date_defaults_to_latest(self):
+        assert _era_for_date(None) == ("xcode-latest", "Xcode latest releases")
+
+
+class TestMergeChangelog:
+    def test_matrix_record_gets_real_release_date(self):
+        results = _parse_feature_matrix(
+            _IDE_CONFIG, _FAKE_HTML, changelog_markdown=_FAKE_CHANGELOG
+        )
+        record = next(r for r in results if r["version"] == "0.48.0")
+        assert record["release_date"] == "2026-04-23"
+
+    def test_matrix_record_keeps_supported_features(self):
+        results = _parse_feature_matrix(
+            _IDE_CONFIG, _FAKE_HTML, changelog_markdown=_FAKE_CHANGELOG
+        )
+        record = next(r for r in results if r["version"] == "0.48.0")
+        assert "### Supported features" in record["body_markdown"]
+        assert "Code completion" in record["body_markdown"]
+
+    def test_matrix_record_includes_changelog_notes(self):
+        results = _parse_feature_matrix(
+            _IDE_CONFIG, _FAKE_HTML, changelog_markdown=_FAKE_CHANGELOG
+        )
+        record = next(r for r in results if r["version"] == "0.48.0")
+        assert "Context window usage details" in record["body_markdown"]
+
+    def test_version_without_changelog_is_unchanged(self):
+        results = _parse_feature_matrix(
+            _IDE_CONFIG, _FAKE_HTML, changelog_markdown=_FAKE_CHANGELOG
+        )
+        # 0.47.0 is in the matrix but not the fake changelog.
+        record = next(r for r in results if r["version"] == "0.47.0")
+        assert "### Supported features" not in record["body_markdown"]
+        assert record["release_date"] == "2026-01-01"
+
+    def test_changelog_only_version_is_added(self):
+        results = _parse_feature_matrix(
+            _IDE_CONFIG, _FAKE_HTML, changelog_markdown=_FAKE_CHANGELOG
+        )
+        versions = {r["version"] for r in results}
+        # 0.31.0 is only in the changelog, not the matrix.
+        assert "0.31.0" in versions
+        record = next(r for r in results if r["version"] == "0.31.0")
+        assert record["xcode_era"] == "xcode-2025"
+        assert record["release_date"] == "2025-02-11"
+        assert "Copilot Chat support" in record["body_markdown"]
+
+    def test_changelog_only_url_points_to_changelog(self):
+        results = _merge_changelog(
+            [],
+            _IDE_CONFIG,
+            _FAKE_CHANGELOG,
+            changelog_url="https://example.test/CHANGELOG.md",
+        )
+        record = next(r for r in results if r["version"] == "0.48.0")
+        assert record["url"] == "https://example.test/CHANGELOG.md"
+
+    def test_merged_records_pass_schema_validation(self):
+        schema = json.loads(pathlib.Path("scripts/common/schema.json").read_text())
+        results = _parse_feature_matrix(
+            _IDE_CONFIG, _FAKE_HTML, changelog_markdown=_FAKE_CHANGELOG
+        )
+        for r in results:
+            r["fetched_at"] = datetime.datetime.now(datetime.UTC).isoformat()
+            r["schema_version"] = 1
+            jsonschema.validate(r, schema)
+
+
+class TestFetchWithChangelog:
+    def test_fetches_changelog_without_auth(self):
+        config = {**_IDE_CONFIG, "changelog_url": "https://example.test/CHANGELOG.md"}
+
+        def fake_get_text(url, *, use_auth):
+            assert use_auth is False
+            return _FAKE_CHANGELOG if url.endswith("CHANGELOG.md") else _FAKE_HTML
+
+        with patch("scripts.fetchers.xcode.get_text", side_effect=fake_get_text):
+            results = fetch(config)
+
+        versions = {r["version"] for r in results}
+        assert "0.31.0" in versions  # changelog-only version present
+        record = next(r for r in results if r["version"] == "0.48.0")
+        assert record["release_date"] == "2026-04-23"
+
+    def test_without_changelog_url_only_calls_source_once(self):
+        with patch("scripts.fetchers.xcode.get_text", return_value=_FAKE_HTML) as mock_get:
+            fetch(_IDE_CONFIG)
+        mock_get.assert_called_once()
+
 

--- a/tests/test_xcode_fetcher.py
+++ b/tests/test_xcode_fetcher.py
@@ -315,6 +315,18 @@ class TestExtractChangelogDates:
         # "## 0.31.0 - February 11, 2025 (Public Preview)"
         assert dates["0.31.0"] == "2025-02-11"
 
+    def test_parses_bracketed_version_headings(self):
+        changelog = (
+            "# Changelog\n\n"
+            "## [0.48.0] - April 23, 2026\n"
+            "### Added\n- Something.\n\n"
+            "## [v0.40.0] - July 24, 2025\n"
+            "### Added\n- Something else.\n"
+        )
+        dates = _extract_changelog_dates(changelog)
+        assert dates["0.48.0"] == "2026-04-23"
+        assert dates["0.40.0"] == "2025-07-24"
+
     def test_returns_empty_for_no_dates(self):
         assert _extract_changelog_dates("## 1.0.0\nNo date here.") == {}
 

--- a/tests/test_xcode_fetcher.py
+++ b/tests/test_xcode_fetcher.py
@@ -387,6 +387,17 @@ class TestMergeChangelog:
         record = next(r for r in results if r["version"] == "0.48.0")
         assert record["url"] == "https://example.test/CHANGELOG.md"
 
+    def test_changelog_url_falls_back_to_config_when_not_passed(self):
+        # A direct caller supplies changelog_markdown but omits changelog_url;
+        # the config's changelog_url must be used, not the feature-matrix source_url.
+        config = {**_IDE_CONFIG, "changelog_url": "https://example.test/CHANGELOG.md"}
+        results = _parse_feature_matrix(
+            config, _FAKE_HTML, changelog_markdown=_FAKE_CHANGELOG
+        )
+        # 0.31.0 is changelog-only, so its url comes from the changelog_url fallback.
+        record = next(r for r in results if r["version"] == "0.31.0")
+        assert record["url"] == "https://example.test/CHANGELOG.md"
+
     def test_merged_records_pass_schema_validation(self):
         schema = json.loads(pathlib.Path("scripts/common/schema.json").read_text())
         results = _parse_feature_matrix(

--- a/tests/test_xcode_fetcher.py
+++ b/tests/test_xcode_fetcher.py
@@ -9,6 +9,7 @@ import pytest
 from bs4 import BeautifulSoup
 
 from scripts.fetchers.xcode import (
+    _SECTIONS,
     _era_for_date,
     _extract_changelog_dates,
     _extract_plugin_versions,
@@ -343,6 +344,16 @@ class TestEraForDate:
 
     def test_missing_date_defaults_to_latest(self):
         assert _era_for_date(None) == ("xcode-latest", "Xcode latest releases")
+
+    def test_sections_ordered_newest_first(self):
+        # _era_for_date relies on _SECTIONS being sorted by start date, newest first.
+        start_dates = [start_date for _, _, start_date in _SECTIONS]
+        assert start_dates == sorted(start_dates, reverse=True)
+
+    def test_section_start_dates_are_iso_format(self):
+        # _era_for_date compares dates lexicographically, which requires ISO YYYY-MM-DD.
+        for _, _, start_date in _SECTIONS:
+            datetime.datetime.strptime(start_date, "%Y-%m-%d")
 
 
 class TestMergeChangelog:


### PR DESCRIPTION
This pull request significantly enhances the Xcode fetcher so that it now combines data from both the [GitHub Copilot feature matrix](https://docs.github.com/en/copilot/reference/copilot-feature-matrix?tool=xcode) and the Copilot For Xcode [CHANGELOG.md](https://github.com/github/CopilotForXcode/blob/main/CHANGELOG.md). This results in more complete and accurate version records, including real release dates and detailed changelog notes. The implementation merges changelog notes into feature matrix records, adds versions only present in the changelog, and ensures all data is fetched without authentication. The tests are expanded to cover these new behaviors.

**Fetcher improvements:**

* The Xcode fetcher now downloads and parses both the feature matrix and the `CHANGELOG.md`, merging changelog notes and real release dates into feature-matrix records, and adding changelog-only versions as extra records. Both sources are fetched without authentication. (`scripts/fetchers/xcode.py`, `config/ides.yml`, `README.md`) [[1]](diffhunk://#diff-415048c9985d21d3a85355a0aa68c25320cd121324c7f1d072d29aeb45981826L1-R19) [[2]](diffhunk://#diff-415048c9985d21d3a85355a0aa68c25320cd121324c7f1d072d29aeb45981826R43-R79) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R78-R79) [[4]](diffhunk://#diff-34c6cb5c3ad9c34e35f56932aa7c35ea11ee90c859e9dca09dcf6fd08b95139eR36)
* New helper functions (`_extract_changelog_dates`, `_era_for_date`, `_compose_body`, `_merge_changelog`) handle parsing changelog headings, associating versions with release eras, and composing the combined record body. (`scripts/fetchers/xcode.py`)

**Documentation:**

* The `README.md` is updated to explain the new data combination logic for Xcode, including how changelog notes and real release dates are handled. (`README.md`)

**Testing:**

* Comprehensive tests are added for the new changelog merging logic, including parsing dates, merging bodies, adding changelog-only versions, and schema validation. (`tests/test_xcode_fetcher.py`) [[1]](diffhunk://#diff-b95c0f4017f7f4ea21406bc91656ecee05e0b655c8c99a3b39e5ea000dea1482R12-R17) [[2]](diffhunk://#diff-b95c0f4017f7f4ea21406bc91656ecee05e0b655c8c99a3b39e5ea000dea1482R31-R49) [[3]](diffhunk://#diff-b95c0f4017f7f4ea21406bc91656ecee05e0b655c8c99a3b39e5ea000dea1482R306-R422)

These changes ensure that the Xcode plugin's version data is much more accurate and informative, with robust test coverage for the new logic.