### PR TITLE
fix(xcode): backfill historical release notes for 0.31.0-0.46.0

### DIFF
--- a/data/xcode/0.31.0.json
+++ b/data/xcode/0.31.0.json
@@ -2,15 +2,17 @@
   "ide": "xcode",
   "version": "0.31.0",
   "xcode_era": "xcode-2025",
-  "release_date": "2025-01-01",
+  "release_date": "2025-02-11",
   "title": "GitHub Copilot for Xcode 0.31.0 – Xcode 2025 releases",
   "url": "https://docs.github.com/en/copilot/reference/copilot-feature-matrix?tool=xcode",
   "source": "html",
-  "body_markdown": "- Chat (P)\n- Code completion",
+  "body_markdown": "### Added\n- Added Copilot Chat support\n- Added GitHub Freeplan support\n- Implemented conversation and chat history management across multiple Xcode instances\n- Introduced multi-file context support for comprehensive code understanding\n- Added slash commands for specialized operations\n\n### Supported features\n- Chat (P)\n- Code completion",
   "body_html": null,
   "categories": [],
-  "copilot_mentions": [],
+  "copilot_mentions": [
+    "- Added Copilot Chat support"
+  ],
   "prerelease": false,
-  "fetched_at": "2026-05-13T10:28:45Z",
+  "fetched_at": "2026-07-10T12:13:00Z",
   "schema_version": 1
 }

--- a/data/xcode/0.32.0.json
+++ b/data/xcode/0.32.0.json
@@ -2,15 +2,15 @@
   "ide": "xcode",
   "version": "0.32.0",
   "xcode_era": "xcode-2025",
-  "release_date": "2025-01-01",
+  "release_date": "2025-03-11",
   "title": "GitHub Copilot for Xcode 0.32.0 – Xcode 2025 releases",
   "url": "https://docs.github.com/en/copilot/reference/copilot-feature-matrix?tool=xcode",
   "source": "html",
-  "body_markdown": "- Chat\n- Code completion",
+  "body_markdown": "### Added\n- Implemented model picker for selecting LLM model in chat\n- Introduced new `/releaseNotes` slash command for accessing release information\n\n### Changed\n- Improved focus handling with automatic switching between chat text field and file search bar\n- Enhanced keyboard navigation support for file picker in chat context\n- Refined instructions for granting accessibility and extension permissions\n- Enhanced accessibility compliance for the chat window\n- Redesigned notification and status bar menu styles for better usability\n\n### Fixed\n- Resolved compatibility issues with macOS 12/13/14\n- Fixed handling of invalid workspace switch event '/'\n- Corrected chat attachment file picker to respect workspace scope\n- Improved icon display consistency across different themes\n- Added support for previously unsupported file types (.md, .txt) in attachments\n- Adjusted incorrect margins in chat window UI\n\n### Supported features\n- Chat\n- Code completion",
   "body_html": null,
   "categories": [],
   "copilot_mentions": [],
   "prerelease": false,
-  "fetched_at": "2026-05-13T10:28:45Z",
+  "fetched_at": "2026-07-10T12:13:00Z",
   "schema_version": 1
 }

--- a/data/xcode/0.33.0.json
+++ b/data/xcode/0.33.0.json
@@ -2,15 +2,18 @@
   "ide": "xcode",
   "version": "0.33.0",
   "xcode_era": "xcode-2025",
-  "release_date": "2025-01-01",
+  "release_date": "2025-04-17",
   "title": "GitHub Copilot for Xcode 0.33.0 – Xcode 2025 releases",
   "url": "https://docs.github.com/en/copilot/reference/copilot-feature-matrix?tool=xcode",
   "source": "html",
-  "body_markdown": "- Chat\n- Code completion",
+  "body_markdown": "### Added\n- Added support for new models in Chat: Claude 3.7 Sonnet and GPT 4.5\n- Implemented @workspace context feature allowing questions about the entire codebase in Copilot Chat\n\n### Changed\n- Simplified access to Copilot Chat from the Copilot for Xcode app with a single click\n- Enhanced instructions for granting background permissions\n\n### Fixed\n- Resolved false alarms for sign-in and free plan limit notifications\n- Improved app launch performance\n- Fixed workspace and context update issues\n\n### Supported features\n- Chat\n- Code completion",
   "body_html": null,
   "categories": [],
-  "copilot_mentions": [],
+  "copilot_mentions": [
+    "- Implemented @workspace context feature allowing questions about the entire codebase in Copilot Chat",
+    "- Simplified access to Copilot Chat from the Copilot for Xcode app with a single click"
+  ],
   "prerelease": false,
-  "fetched_at": "2026-05-13T10:28:45Z",
+  "fetched_at": "2026-07-10T12:13:00Z",
   "schema_version": 1
 }

--- a/data/xcode/0.34.0.json
+++ b/data/xcode/0.34.0.json
@@ -2,15 +2,15 @@
   "ide": "xcode",
   "version": "0.34.0",
   "xcode_era": "xcode-2025",
-  "release_date": "2025-01-01",
+  "release_date": "2025-04-29",
   "title": "GitHub Copilot for Xcode 0.34.0 – Xcode 2025 releases",
   "url": "https://docs.github.com/en/copilot/reference/copilot-feature-matrix?tool=xcode",
   "source": "html",
-  "body_markdown": "- Chat\n- Code completion",
+  "body_markdown": "### Added\n- Added support for new models in Chat: OpenAI GPT-4.1, o3 and o4-mini, Gemini 2.5 Pro\n\n### Changed\n- Switched default model to GPT-4.1 for new installations\n- Enhanced model selection interface\n\n### Fixed\n- Resolved critical error handling issues\n\n### Supported features\n- Chat\n- Code completion",
   "body_html": null,
   "categories": [],
   "copilot_mentions": [],
   "prerelease": false,
-  "fetched_at": "2026-05-13T10:28:45Z",
+  "fetched_at": "2026-07-10T12:13:00Z",
   "schema_version": 1
 }

--- a/data/xcode/0.35.0.json
+++ b/data/xcode/0.35.0.json
@@ -2,15 +2,17 @@
   "ide": "xcode",
   "version": "0.35.0",
   "xcode_era": "xcode-2025",
-  "release_date": "2025-01-01",
+  "release_date": "2025-05-19",
   "title": "GitHub Copilot for Xcode 0.35.0 – Xcode 2025 releases",
   "url": "https://docs.github.com/en/copilot/reference/copilot-feature-matrix?tool=xcode",
   "source": "html",
-  "body_markdown": "- Agent mode (P)\n- Chat\n- Code completion\n- MCP (P)",
+  "body_markdown": "### Added\n- Launched Agent Mode. Copilot will automatically use multiple requests to edit files, run terminal commands, and fix errors.\n- Introduced Model Context Protocol (MCP) support in Agent Mode, allowing you to configure MCP tools to extend capabilities.\n\n### Changed\n- Added a button to enable/disable referencing current file in conversations\n- Added an animated progress icon in the response section\n- Refined onboarding experience with updated instruction screens and welcome views\n- Improved conversation reliability with extended timeout limits for agent requests\n\n### Fixed\n- Addressed critical error handling issues in core functionality\n- Resolved UI inconsistencies with chat interface padding adjustments\n- Implemented custom certificate handling using system environment variables `NODE_EXTRA_CA_CERTS` and `NODE_TLS_REJECT_UNAUTHORIZED`, fixing network access issues\n\n### Supported features\n- Agent mode (P)\n- Chat\n- Code completion\n- MCP (P)",
   "body_html": null,
   "categories": [],
-  "copilot_mentions": [],
+  "copilot_mentions": [
+    "- Launched Agent Mode. Copilot will automatically use multiple requests to edit files, run terminal commands, and fix errors."
+  ],
   "prerelease": false,
-  "fetched_at": "2026-05-13T10:28:45Z",
+  "fetched_at": "2026-07-10T12:13:00Z",
   "schema_version": 1
 }

--- a/data/xcode/0.36.0.json
+++ b/data/xcode/0.36.0.json
@@ -2,15 +2,17 @@
   "ide": "xcode",
   "version": "0.36.0",
   "xcode_era": "xcode-2025",
-  "release_date": "2025-01-01",
+  "release_date": "2025-06-04",
   "title": "GitHub Copilot for Xcode 0.36.0 – Xcode 2025 releases",
   "url": "https://docs.github.com/en/copilot/reference/copilot-feature-matrix?tool=xcode",
   "source": "html",
-  "body_markdown": "- Agent mode (P)\n- Chat\n- Code completion\n- MCP (P)",
+  "body_markdown": "### Added\n- Introduced a new chat setting \"**Response Language**\" under **Advanced** settings to customize the natural language used in chat replies.\n- Enabled support for custom instructions defined in _.github/copilot-instructions.md_ within your workspace.\n- Added support for premium request handling.\n\n### Fixed\n- Performance: Improved UI responsiveness by lazily restoring chat history.\n- Performance: Fixed lagging issue when pasting large text into the chat input.\n- Performance: Improved project indexing performance.\n- Don't trigger / (slash) commands when pasting a file path into the chat input.\n- Adjusted terminal text styling to align with Xcode's theme.\n\n### Supported features\n- Agent mode (P)\n- Chat\n- Code completion\n- MCP (P)",
   "body_html": null,
   "categories": [],
-  "copilot_mentions": [],
+  "copilot_mentions": [
+    "- Enabled support for custom instructions defined in _.github/copilot-instructions.md_ within your workspace."
+  ],
   "prerelease": false,
-  "fetched_at": "2026-05-13T10:28:45Z",
+  "fetched_at": "2026-07-10T12:13:00Z",
   "schema_version": 1
 }

--- a/data/xcode/0.37.0.json
+++ b/data/xcode/0.37.0.json
@@ -2,15 +2,17 @@
   "ide": "xcode",
   "version": "0.37.0",
   "xcode_era": "xcode-2025",
-  "release_date": "2025-01-01",
+  "release_date": "2025-06-18",
   "title": "GitHub Copilot for Xcode 0.37.0 – Xcode 2025 releases",
   "url": "https://docs.github.com/en/copilot/reference/copilot-feature-matrix?tool=xcode",
   "source": "html",
-  "body_markdown": "- Agent mode (P)\n- Chat\n- Code completion\n- MCP (P)",
+  "body_markdown": "### Added\n- **Advanced** settings: Added option to configure **Custom Instructions** for GitHub Copilot during chat sessions.\n- **Advanced** settings: Added option to keep the chat window automatically attached to Xcode.\n\n### Changed\n- Enabled support for dragging-and-dropping files into the chat panel to provide context.\n\n### Fixed\n- \"Add Context\" menu didn't show files in workspaces organized with Xcode's group feature.\n- Chat didn't respond when the workspace was in a system folder (like Desktop, Downloads, or Documents) and access permission hadn't been granted.\n\n### Supported features\n- Agent mode (P)\n- Chat\n- Code completion\n- MCP (P)",
   "body_html": null,
   "categories": [],
-  "copilot_mentions": [],
+  "copilot_mentions": [
+    "- **Advanced** settings: Added option to configure **Custom Instructions** for GitHub Copilot during chat sessions."
+  ],
   "prerelease": false,
-  "fetched_at": "2026-05-13T10:28:45Z",
+  "fetched_at": "2026-07-10T12:13:00Z",
   "schema_version": 1
 }

--- a/data/xcode/0.38.0.json
+++ b/data/xcode/0.38.0.json
@@ -2,15 +2,18 @@
   "ide": "xcode",
   "version": "0.38.0",
   "xcode_era": "xcode-2025",
-  "release_date": "2025-01-01",
+  "release_date": "2025-06-30",
   "title": "GitHub Copilot for Xcode 0.38.0 – Xcode 2025 releases",
   "url": "https://docs.github.com/en/copilot/reference/copilot-feature-matrix?tool=xcode",
   "source": "html",
-  "body_markdown": "- Agent mode\n- Chat\n- Code completion\n- Custom instructions (P)\n- MCP (P)\n- Vision (P)",
+  "body_markdown": "### Added\n- Support for Claude 4 in Chat.\n- Support for Copilot Vision (image attachments).\n- Support for remote MCP servers.\n\n### Changed\n- Automatically suggests a title for conversations created in agent mode.\n- Improved restoration of MCP tool status after Copilot restarts.\n- Reduced duplication of MCP server instances.\n\n### Fixed\n- Switching accounts now correctly refreshes the auth token and models.\n- Fixed file create/edit issues in agent mode.\n\n### Supported features\n- Agent mode\n- Chat\n- Code completion\n- Custom instructions (P)\n- MCP (P)\n- Vision (P)",
   "body_html": null,
   "categories": [],
-  "copilot_mentions": [],
+  "copilot_mentions": [
+    "- Support for Copilot Vision (image attachments).",
+    "- Improved restoration of MCP tool status after Copilot restarts."
+  ],
   "prerelease": false,
-  "fetched_at": "2026-05-13T10:28:45Z",
+  "fetched_at": "2026-07-10T12:13:00Z",
   "schema_version": 1
 }

--- a/data/xcode/0.39.0.json
+++ b/data/xcode/0.39.0.json
@@ -2,15 +2,15 @@
   "ide": "xcode",
   "version": "0.39.0",
   "xcode_era": "xcode-2025",
-  "release_date": "2025-01-01",
+  "release_date": "2025-07-23",
   "title": "GitHub Copilot for Xcode 0.39.0 – Xcode 2025 releases",
   "url": "https://docs.github.com/en/copilot/reference/copilot-feature-matrix?tool=xcode",
   "source": "html",
-  "body_markdown": "- Agent mode\n- Chat\n- Code completion\n- Custom instructions (P)\n- MCP (P)\n- Vision (P)",
+  "body_markdown": "### Fixed\n- Performance: Fixed a freezing issue in 'Add Context' view when opening large projects.\n- Login failed due to insufficient permissions on the .config folder.\n- Fixed an issue that setting changes like proxy config did not take effect.\n- Increased the timeout for ask mode to prevent response failures due to timeout.\n\n### Supported features\n- Agent mode\n- Chat\n- Code completion\n- Custom instructions (P)\n- MCP (P)\n- Vision (P)",
   "body_html": null,
   "categories": [],
   "copilot_mentions": [],
   "prerelease": false,
-  "fetched_at": "2026-05-13T10:28:45Z",
+  "fetched_at": "2026-07-10T12:13:00Z",
   "schema_version": 1
 }

--- a/data/xcode/0.40.0.json
+++ b/data/xcode/0.40.0.json
@@ -2,15 +2,15 @@
   "ide": "xcode",
   "version": "0.40.0",
   "xcode_era": "xcode-2025",
-  "release_date": "2025-01-01",
+  "release_date": "2025-07-24",
   "title": "GitHub Copilot for Xcode 0.40.0 – Xcode 2025 releases",
   "url": "https://docs.github.com/en/copilot/reference/copilot-feature-matrix?tool=xcode",
   "source": "html",
-  "body_markdown": "- Agent mode\n- Chat\n- Code completion\n- Custom instructions (P)\n- MCP (P)\n- Vision (P)",
+  "body_markdown": "### Added\n- Support disabling Agent mode when it's disabled by policy.\n\n### Supported features\n- Agent mode\n- Chat\n- Code completion\n- Custom instructions (P)\n- MCP (P)\n- Vision (P)",
   "body_html": null,
   "categories": [],
   "copilot_mentions": [],
   "prerelease": false,
-  "fetched_at": "2026-05-13T10:28:45Z",
+  "fetched_at": "2026-07-10T12:13:00Z",
   "schema_version": 1
 }

--- a/data/xcode/0.41.0.json
+++ b/data/xcode/0.41.0.json
@@ -2,17 +2,18 @@
   "ide": "xcode",
   "version": "0.41.0",
   "xcode_era": "xcode-2025",
-  "release_date": "2025-01-01",
+  "release_date": "2025-08-14",
   "title": "GitHub Copilot for Xcode 0.41.0 – Xcode 2025 releases",
   "url": "https://docs.github.com/en/copilot/reference/copilot-feature-matrix?tool=xcode",
   "source": "html",
-  "body_markdown": "- Agent mode\n- Chat\n- Code completion\n- Copilot code review\n- Custom instructions (P)\n- MCP\n- Vision (P)",
+  "body_markdown": "### Added\n- Code review feature.\n- Chat: Support for new model GPT-5.\n- Agent mode: Added support for new tool to read web URL contents.\n- Support disabling MCP when it's disabled by policy.\n- Support for opening MCP logs directly from the MCP settings page.\n- OAuth support for remote GitHub MCP server.\n\n### Changed\n- Performance: Improved instant-apply speed for edit_file tool.\n\n### Fixed\n- Chat Agent repeatedly reverts its own changes when editing the same file.\n- Performance: Avoid chat panel being stuck when sending a large text for chat.\n\n### Supported features\n- Agent mode\n- Chat\n- Code completion\n- Copilot code review\n- Custom instructions (P)\n- MCP\n- Vision (P)",
   "body_html": null,
   "categories": [],
   "copilot_mentions": [
+    "- Chat Agent repeatedly reverts its own changes when editing the same file.",
     "- Copilot code review"
   ],
   "prerelease": false,
-  "fetched_at": "2026-05-13T10:28:45Z",
+  "fetched_at": "2026-07-10T12:13:00Z",
   "schema_version": 1
 }

--- a/data/xcode/0.42.0.json
+++ b/data/xcode/0.42.0.json
@@ -2,17 +2,17 @@
   "ide": "xcode",
   "version": "0.42.0",
   "xcode_era": "xcode-latest",
-  "release_date": "2026-01-01",
+  "release_date": "2025-09-03",
   "title": "GitHub Copilot for Xcode 0.42.0 – Xcode latest releases",
   "url": "https://docs.github.com/en/copilot/reference/copilot-feature-matrix?tool=xcode",
   "source": "html",
-  "body_markdown": "- Agent mode\n- BYOK (P)\n- Chat\n- Code completion\n- Copilot code review\n- Custom instructions (P)\n- MCP\n- Prompt files (P)\n- Vision (P)",
+  "body_markdown": "### Added\n- Support for Bring Your Own Keys (BYOK) with model providers including Azure, OpenAI, Anthropic, Gemini, Groq, and OpenRouter. See [BYOK.md](https://github.com/github/CopilotForXcode/blob/0.42.0/Docs/BYOK.md).\n- Use the current selection as chat context.\n- Add folders as chat context.\n- Shortcut to quickly fix errors in Xcode.\n- Support for custom instruction files at `.github/instructions/*.instructions.md`. See [CustomInstructions.md](https://github.com/github/CopilotForXcode/blob/0.42.0/Docs/CustomInstructions.md).\n- Support for prompt files at `.github/prompts/*.prompt.md`. See [PromptFiles.md](https://github.com/github/CopilotForXcode/blob/0.42.0/Docs/PromptFiles.md).\n- Use ↑/↓ keys to reuse previous chat context in the chat view.\n\n### Changed\n- Default chat mode is now set to \"Agent\".\n\n### Fixed\n- Cannot copy url from Safari browser to chat view.\n\n### Supported features\n- Agent mode\n- BYOK (P)\n- Chat\n- Code completion\n- Copilot code review\n- Custom instructions (P)\n- MCP\n- Prompt files (P)\n- Vision (P)",
   "body_html": null,
   "categories": [],
   "copilot_mentions": [
     "- Copilot code review"
   ],
   "prerelease": false,
-  "fetched_at": "2026-05-13T10:28:45Z",
+  "fetched_at": "2026-07-10T12:13:00Z",
   "schema_version": 1
 }

--- a/data/xcode/0.43.0.json
+++ b/data/xcode/0.43.0.json
@@ -2,17 +2,17 @@
   "ide": "xcode",
   "version": "0.43.0",
   "xcode_era": "xcode-latest",
-  "release_date": "2026-01-01",
+  "release_date": "2025-09-04",
   "title": "GitHub Copilot for Xcode 0.43.0 – Xcode latest releases",
   "url": "https://docs.github.com/en/copilot/reference/copilot-feature-matrix?tool=xcode",
   "source": "html",
-  "body_markdown": "- Agent mode\n- BYOK (P)\n- Chat\n- Code completion\n- Copilot code review\n- Custom instructions (P)\n- MCP\n- Prompt files (P)\n- Vision (P)",
+  "body_markdown": "### Fixed\n- Cannot type non-Latin characters in the chat input field.\n\n### Supported features\n- Agent mode\n- BYOK (P)\n- Chat\n- Code completion\n- Copilot code review\n- Custom instructions (P)\n- MCP\n- Prompt files (P)\n- Vision (P)",
   "body_html": null,
   "categories": [],
   "copilot_mentions": [
     "- Copilot code review"
   ],
   "prerelease": false,
-  "fetched_at": "2026-05-13T10:28:45Z",
+  "fetched_at": "2026-07-10T12:13:00Z",
   "schema_version": 1
 }

--- a/data/xcode/0.44.0.json
+++ b/data/xcode/0.44.0.json
@@ -2,17 +2,20 @@
   "ide": "xcode",
   "version": "0.44.0",
   "xcode_era": "xcode-latest",
-  "release_date": "2026-01-01",
+  "release_date": "2025-10-15",
   "title": "GitHub Copilot for Xcode 0.44.0 – Xcode latest releases",
   "url": "https://docs.github.com/en/copilot/reference/copilot-feature-matrix?tool=xcode",
   "source": "html",
-  "body_markdown": "- Agent mode\n- BYOK (P)\n- Chat\n- Checkpoints\n- Code completion\n- Copilot code review\n- Custom instructions (P)\n- MCP\n- Prompt files (P)\n- Vision (P)",
+  "body_markdown": "### Added\n- Added support for new models in Chat: Grok Code Fast 1, Claude Sonnet 4.5, Claude Opus 4, Claude Opus 4.1 and GPT-5 mini.\n- Added support for restoring to a saved checkpoint snapshot.\n- Added support for tool selection in agent mode.\n- Added the ability to adjust the chat panel font size.\n- Added the ability to edit a previous chat message and resend it.\n- Introduced a new setting to disable the Copilot \"Fix Error\" button.\n- Added support for custom instructions in the Code Review feature.\n\n### Changed\n- Switched authentication to a new OAuth app \"GitHub Copilot IDE Plugin\".\n- Updated the chat layout to a messenger-style conversation view (user messages on the right, responses on the left).\n- Now shows a clearer, more user-friendly message when Copilot finishes responding.\n- Added support for skipping a tool call without ending the conversation.\n\n### Fixed\n- Fixed a command injection vulnerability when opening referenced chat files.\n- Resolved display issues in the chat view on macOS 26.\n\n### Supported features\n- Agent mode\n- BYOK (P)\n- Chat\n- Checkpoints\n- Code completion\n- Copilot code review\n- Custom instructions (P)\n- MCP\n- Prompt files (P)\n- Vision (P)",
   "body_html": null,
   "categories": [],
   "copilot_mentions": [
+    "- Introduced a new setting to disable the Copilot \"Fix Error\" button.",
+    "- Switched authentication to a new OAuth app \"GitHub Copilot IDE Plugin\".",
+    "- Now shows a clearer, more user-friendly message when Copilot finishes responding.",
     "- Copilot code review"
   ],
   "prerelease": false,
-  "fetched_at": "2026-05-13T10:28:45Z",
+  "fetched_at": "2026-07-10T12:13:00Z",
   "schema_version": 1
 }

--- a/data/xcode/0.45.0.json
+++ b/data/xcode/0.45.0.json
@@ -2,17 +2,17 @@
   "ide": "xcode",
   "version": "0.45.0",
   "xcode_era": "xcode-latest",
-  "release_date": "2026-01-01",
+  "release_date": "2025-11-14",
   "title": "GitHub Copilot for Xcode 0.45.0 – Xcode latest releases",
   "url": "https://docs.github.com/en/copilot/reference/copilot-feature-matrix?tool=xcode",
   "source": "html",
-  "body_markdown": "- Agent mode\n- BYOK (P)\n- Chat\n- Checkpoints\n- Code completion\n- Copilot code review\n- Custom agents (P)\n- Custom instructions (P)\n- MCP\n- Next edit suggestions (P)\n- Prompt files (P)\n- Vision (P)",
+  "body_markdown": "### Added\n- New models: GPT-5.1, GPT-5.1-Codex, GPT-5.1-Codex-Mini, Claude Haiku 4.5, and Auto (preview).\n- Added support for custom agents (preview).\n- Introduced the built-in Plan agent (preview).\n- Added support for subagent execution (preview).\n- Added support for Next Edit Suggestions (preview).\n\n### Changed\n- MCP servers now support dynamic OAuth setup for third-party authentication providers.\n- Added a setting to configure the maximum number of tool requests allowed.\n\n### Fixed\n- Fixed an issue that the terminal view in Agent conversation was clipped\n- Fixed an issue that the Chat panel failed to recognize newly created workspaces.\n\n### Supported features\n- Agent mode\n- BYOK (P)\n- Chat\n- Checkpoints\n- Code completion\n- Copilot code review\n- Custom agents (P)\n- Custom instructions (P)\n- MCP\n- Next edit suggestions (P)\n- Prompt files (P)\n- Vision (P)",
   "body_html": null,
   "categories": [],
   "copilot_mentions": [
     "- Copilot code review"
   ],
   "prerelease": false,
-  "fetched_at": "2026-05-13T10:28:45Z",
+  "fetched_at": "2026-07-10T12:13:00Z",
   "schema_version": 1
 }

--- a/data/xcode/0.46.0.json
+++ b/data/xcode/0.46.0.json
@@ -2,17 +2,17 @@
   "ide": "xcode",
   "version": "0.46.0",
   "xcode_era": "xcode-latest",
-  "release_date": "2026-01-01",
+  "release_date": "2025-12-11",
   "title": "GitHub Copilot for Xcode 0.46.0 – Xcode latest releases",
   "url": "https://docs.github.com/en/copilot/reference/copilot-feature-matrix?tool=xcode",
   "source": "html",
-  "body_markdown": "- Agent mode\n- BYOK (P)\n- Chat\n- Checkpoints\n- Code completion\n- Copilot code review\n- Custom agents (P)\n- Custom instructions (P)\n- MCP\n- Next edit suggestions (P)\n- Prompt files (P)\n- Vision (P)",
+  "body_markdown": "### Added\n- MCP: Support delete MCP server from list.\n\n### Changed\n- Refine built-in tools layout and displaying error and output details.\n- Better support toolCallingLoop continue operation for subagent turn.\n- Update feedback forum link.\n- Update client-side MCP restore and persist.\n- Adopt NES notification.\n\n### Fixed\n- Disable auto focus for fix error window.\n- Fixed an issue where no file change was made when insert_edit_into_file tool succeeds.\n- Fixed an issue where insert edit was applied to the incorrect file.\n- Fixed model picker to use model id instead of model family.\n- Fixed read_file, read_directory tool randomly failing.\n\n### Supported features\n- Agent mode\n- BYOK (P)\n- Chat\n- Checkpoints\n- Code completion\n- Copilot code review\n- Custom agents (P)\n- Custom instructions (P)\n- MCP\n- Next edit suggestions (P)\n- Prompt files (P)\n- Vision (P)",
   "body_html": null,
   "categories": [],
   "copilot_mentions": [
     "- Copilot code review"
   ],
   "prerelease": false,
-  "fetched_at": "2026-05-13T10:28:45Z",
+  "fetched_at": "2026-07-10T12:13:00Z",
   "schema_version": 1
 }

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -40,9 +40,8 @@ def test_write_release_idempotent() -> None:
     files (e.g. the Xcode 0.31-0.46 era) were written by a one-time manual
     backfill script that enriched them with correct release dates and
     per-release changelog notes sourced from CopilotForXcode/CHANGELOG.md.
-    Those files must NOT be overwritten by future scheduled workflow runs,
-    which only know about the feature-matrix page and would produce inferior
-    data (wrong dates, no changelog notes).
+    Those files must NOT be overwritten by future scheduled workflow runs; otherwise manual corrections
+    (and any future regressions in fetcher output) could be lost.
 
     If this test fails after a change to write_release, verify that the
     idempotency guarantee is still upheld before merging, otherwise the

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -34,21 +34,36 @@ def test_write_release_creates_file() -> None:
 
 
 def test_write_release_idempotent() -> None:
-    """Test that write_release doesn't overwrite existing files."""
+    """Test that write_release never overwrites an existing file.
+
+    This behaviour is load-bearing for historical backfills: some IDE data
+    files (e.g. the Xcode 0.31-0.46 era) were written by a one-time manual
+    backfill script that enriched them with correct release dates and
+    per-release changelog notes sourced from CopilotForXcode/CHANGELOG.md.
+    Those files must NOT be overwritten by future scheduled workflow runs,
+    which only know about the feature-matrix page and would produce inferior
+    data (wrong dates, no changelog notes).
+
+    If this test fails after a change to write_release, verify that the
+    idempotency guarantee is still upheld before merging, otherwise the
+    next workflow run will silently discard manually backfilled data.
+    """
     with tempfile.TemporaryDirectory() as tmpdir:
         data_dir = pathlib.Path(tmpdir)
         release = {
             "version": "1.0.0",
             "release_date": "2026-01-01",
         }
-        
+
         # First write should succeed
         result1 = write_release(data_dir, release)
         assert result1 is True
-        
-        # Second write should be skipped
-        result2 = write_release(data_dir, release)
+
+        # Second write must be skipped — the file on disk must not change
+        original_content = (data_dir / "1.0.0.json").read_text(encoding="utf-8")
+        result2 = write_release(data_dir, {**release, "release_date": "2099-12-31"})
         assert result2 is False
+        assert (data_dir / "1.0.0.json").read_text(encoding="utf-8") == original_content
 
 
 def test_generate_ide_index_creates_index() -> None:


### PR DESCRIPTION
## Summary

Versions 0.31.0-0.46.0 were originally created from the GitHub Docs feature-matrix page, which only provided era-level placeholder dates (2025-01-01 / 2026-01-01) and no per-release changelog notes. This PR backfills all 16 files with accurate data from [CopilotForXcode/CHANGELOG.md](https://github.com/github/CopilotForXcode/blob/main/CHANGELOG.md).

## Changes

**16 historical data files updated** (data/xcode/0.31.0.json - data/xcode/0.46.0.json)